### PR TITLE
feat: sidebar and layout consolidation (#35)

### DIFF
--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -1,7 +1,9 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useAppStore } from "../../stores/appStore";
+import { useMembersStore } from "../../stores/members";
 import { useServerStore } from "../../stores/serverStore";
+import { MemberList } from "../members/MemberList";
 import { ChannelSidebar } from "./ChannelSidebar";
 import { MessageView } from "./MessageView";
 import { ServerSidebar } from "./ServerSidebar";
@@ -9,6 +11,8 @@ import { ServerSidebar } from "./ServerSidebar";
 export function AppShell() {
   const { currentServerId, servers, setCurrentServer } = useAppStore();
   const {
+    address,
+    sessionToken,
     channels,
     currentChannelId,
     messages,
@@ -18,6 +22,36 @@ export function AppShell() {
     sendMessage,
     loadMoreMessages,
   } = useServerStore();
+
+  const members = useMembersStore((state) => state.members);
+  const fetchMembers = useMembersStore((state) => state.fetchMembers);
+  const kickMember = useMembersStore((state) => state.kick);
+  const banMember = useMembersStore((state) => state.ban);
+
+  const [memberPanelOpen, setMemberPanelOpen] = useState(true);
+
+  // Fetch members when connected to a server
+  useEffect(() => {
+    if (address && sessionToken && status === "connected") {
+      void fetchMembers(address, sessionToken);
+    }
+  }, [address, sessionToken, status, fetchMembers]);
+
+  const handleKick = useCallback(
+    async (pubkey: string) => {
+      if (!address || !sessionToken) throw new Error("Not connected");
+      await kickMember(address, sessionToken, pubkey);
+    },
+    [address, sessionToken, kickMember],
+  );
+
+  const handleBan = useCallback(
+    async (pubkey: string, reason?: string) => {
+      if (!address || !sessionToken) throw new Error("Not connected");
+      await banMember(address, sessionToken, pubkey, reason);
+    },
+    [address, sessionToken, banMember],
+  );
 
   const serverList = useMemo(() => Object.values(servers), [servers]);
   const currentChannel = channels.find((ch) => ch.id === currentChannelId) ?? null;
@@ -48,7 +82,14 @@ export function AppShell() {
           currentChannelId ? loadMoreMessages(currentChannelId) : Promise.resolve()
         }
         onSend={sendMessage}
+        memberPanelOpen={memberPanelOpen}
+        onToggleMemberPanel={() => setMemberPanelOpen((v) => !v)}
       />
+      {memberPanelOpen && currentServerId && status === "connected" && (
+        <aside className="w-64 border-l border-ctp-overlay0 bg-ctp-mantle overflow-y-auto shrink-0">
+          <MemberList members={members} onKick={handleKick} onBan={handleBan} />
+        </aside>
+      )}
     </main>
   );
 }

--- a/client/src/components/layout/MessageView.tsx
+++ b/client/src/components/layout/MessageView.tsx
@@ -10,6 +10,8 @@ interface MessageViewProps {
   connected: boolean;
   onLoadMore: () => Promise<void>;
   onSend: (content: string) => Promise<void>;
+  memberPanelOpen?: boolean;
+  onToggleMemberPanel?: () => void;
 }
 
 export function MessageView({
@@ -19,6 +21,8 @@ export function MessageView({
   connected,
   onLoadMore,
   onSend,
+  memberPanelOpen,
+  onToggleMemberPanel,
 }: MessageViewProps) {
   const permissions = usePermissions(channel?.id);
 
@@ -32,8 +36,21 @@ export function MessageView({
 
   return (
     <section className="flex h-full flex-1 flex-col bg-ctp-base">
-      <header className="border-b border-ctp-overlay0 px-5 py-4">
+      <header className="border-b border-ctp-overlay0 px-5 py-4 flex items-center justify-between">
         <h2 className="text-lg font-bold text-ctp-text">#{channel.name}</h2>
+        {onToggleMemberPanel && (
+          <button
+            onClick={onToggleMemberPanel}
+            title={memberPanelOpen ? "Hide members" : "Show members"}
+            className={`h-8 w-8 rounded-lg transition flex items-center justify-center text-sm ${
+              memberPanelOpen
+                ? "bg-ctp-blue text-ctp-crust"
+                : "bg-ctp-surface0 text-ctp-subtext1 hover:bg-ctp-surface1"
+            }`}
+          >
+            👥
+          </button>
+        )}
       </header>
       <div className="flex-1 min-h-0">
         <MessageList messages={messages} hasMore={hasMore} onLoadMore={onLoadMore} />

--- a/client/src/components/layout/ServerSidebar.tsx
+++ b/client/src/components/layout/ServerSidebar.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 
 import { CreateInviteDialog } from "../invites/CreateInviteDialog";
-import { MemberList } from "../members/MemberList";
 import { AllowlistEditor } from "../settings/AllowlistEditor";
 import { BanList } from "../settings/BanList";
 import { MembershipSettings } from "../settings/MembershipSettings";
 import { InviteList } from "../invites/InviteList";
 import { ProfileEditor } from "../profile/ProfileEditor";
 import { ThemeSwitcher } from "../settings/ThemeSwitcher";
-import { BAN_MEMBERS, MANAGE_INVITES, MANAGE_SERVER, usePermissions } from "../../hooks/usePermissions";
+import {
+  BAN_MEMBERS,
+  MANAGE_INVITES,
+  MANAGE_ROLES,
+  MANAGE_SERVER,
+  usePermissions,
+} from "../../hooks/usePermissions";
 import { useAppStore } from "../../stores/appStore";
 import { useInvitesStore } from "../../stores/invites";
 import { useMembersStore } from "../../stores/members";
@@ -19,6 +24,8 @@ interface ServerSidebarProps {
   currentServerId: string | null;
   onSelectServer: (id: string) => void;
 }
+
+type OpenPanel = null | "user-settings" | "server-settings";
 
 function initials(name: string | undefined, address: string): string {
   if (!name || name.trim() === "") {
@@ -38,10 +45,10 @@ function initials(name: string | undefined, address: string): string {
   }
   return name.slice(0, 2).toUpperCase();
 }
+
 export function ServerSidebar({ servers, currentServerId, onSelectServer }: ServerSidebarProps) {
   const { theme, setTheme, setCurrentServer, removeServer } = useAppStore();
   const address = useServerStore((state) => state.address);
-  // ... rest of imports
 
   const token = useServerStore((state) => state.sessionToken);
   const roles = useServerStore((state) => state.roles);
@@ -49,6 +56,8 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer }: Serv
   const canManageInvites = permissions.has(MANAGE_INVITES);
   const canBanMembers = permissions.has(BAN_MEMBERS);
   const canManageServer = permissions.has(MANAGE_SERVER);
+  const canManageRoles = permissions.has(MANAGE_ROLES);
+  const showServerSettings = canManageInvites || canBanMembers || canManageServer || canManageRoles;
 
   const invites = useInvitesStore((state) => state.invites);
   const loadingInvites = useInvitesStore((state) => state.loading);
@@ -56,32 +65,22 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer }: Serv
   const createInvite = useInvitesStore((state) => state.createInvite);
   const revokeInvite = useInvitesStore((state) => state.revokeInvite);
 
-  const members = useMembersStore((state) => state.members);
   const bans = useMembersStore((state) => state.bans);
   const allowlist = useMembersStore((state) => state.allowlist);
-  const fetchMembers = useMembersStore((state) => state.fetchMembers);
   const fetchBans = useMembersStore((state) => state.fetchBans);
   const fetchAllowlist = useMembersStore((state) => state.fetchAllowlist);
-  const kickMember = useMembersStore((state) => state.kick);
-  const banMember = useMembersStore((state) => state.ban);
   const unbanMember = useMembersStore((state) => state.unban);
   const addAllowlist = useMembersStore((state) => state.addAllowlistEntry);
   const removeAllowlist = useMembersStore((state) => state.removeAllowlistEntry);
 
-  const [themeOpen, setThemeOpen] = useState(false);
-  const [inviteOpen, setInviteOpen] = useState(false);
-  const [membersOpen, setMembersOpen] = useState(false);
-  const [profileOpen, setProfileOpen] = useState(false);
+  const [openPanel, setOpenPanel] = useState<OpenPanel>(null);
 
   const sidebarRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (sidebarRef.current && !sidebarRef.current.contains(event.target as Node)) {
-        setThemeOpen(false);
-        setInviteOpen(false);
-        setMembersOpen(false);
-        setProfileOpen(false);
+        setOpenPanel(null);
       }
     }
 
@@ -91,18 +90,17 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer }: Serv
     };
   }, []);
 
-  async function refreshInvites() {
-    if (!address || !token) {
-      return;
-    }
-    await fetchInvites(address, token);
+  function togglePanel(panel: OpenPanel) {
+    setOpenPanel((prev) => (prev === panel ? null : panel));
   }
 
-  async function refreshMembersPanel() {
+  async function refreshServerSettings() {
     if (!address || !token) {
       return;
     }
-    await fetchMembers(address, token);
+    if (canManageInvites) {
+      await fetchInvites(address, token);
+    }
     if (canBanMembers) {
       await fetchBans(address, token);
     }
@@ -152,116 +150,83 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer }: Serv
         );
       })}
 
-      <div className="mt-auto">
-        {canManageInvites && (
-          <button
-            onClick={() => {
-              const next = !inviteOpen;
-              setInviteOpen(next);
-              if (next) {
-                void refreshInvites();
-              }
-            }}
-            title="Invite settings"
-            className="mb-3 h-12 w-12 rounded-xl bg-ctp-surface0 text-ctp-subtext1 hover:bg-ctp-surface1 transition flex items-center justify-center text-[10px] font-bold"
-          >
-            INV
-          </button>
-        )}
+      <div className="mt-auto flex flex-col gap-3">
         <button
-          onClick={() => {
-            const next = !membersOpen;
-            setMembersOpen(next);
-            if (next) {
-              void refreshMembersPanel();
-            }
-          }}
-          title="Membership"
-          className="mb-3 h-12 w-12 rounded-xl bg-ctp-surface0 text-ctp-subtext1 hover:bg-ctp-surface1 transition"
-        >
-          👥
-        </button>
-        <button
-          onClick={() => setProfileOpen((v) => !v)}
-          title="My profile"
-          className="mb-3 h-12 w-12 rounded-xl bg-ctp-surface0 text-ctp-subtext1 hover:bg-ctp-surface1 transition"
+          onClick={() => togglePanel("user-settings")}
+          title="User settings"
+          className={`h-12 w-12 rounded-xl transition flex items-center justify-center ${
+            openPanel === "user-settings"
+              ? "bg-ctp-blue text-ctp-crust"
+              : "bg-ctp-surface0 text-ctp-subtext1 hover:bg-ctp-surface1"
+          }`}
         >
           👤
         </button>
-        <button
-          onClick={() => setThemeOpen((v) => !v)}
-          title="Theme settings"
-          className="h-12 w-12 rounded-xl bg-ctp-surface0 text-ctp-subtext1 hover:bg-ctp-surface1 transition"
-        >
-          ⚙
-        </button>
+        {showServerSettings && (
+          <button
+            onClick={() => {
+              const willOpen = openPanel !== "server-settings";
+              togglePanel("server-settings");
+              if (willOpen) {
+                void refreshServerSettings();
+              }
+            }}
+            title="Server settings"
+            className={`h-12 w-12 rounded-xl transition flex items-center justify-center ${
+              openPanel === "server-settings"
+                ? "bg-ctp-blue text-ctp-crust"
+                : "bg-ctp-surface0 text-ctp-subtext1 hover:bg-ctp-surface1"
+            }`}
+          >
+            ⚙
+          </button>
+        )}
       </div>
 
-      {themeOpen && (
-        <div className="absolute bottom-3 left-20 z-10 w-56 pl-2">
-          <ThemeSwitcher
-            theme={theme}
-            onThemeSelect={(next) => {
-              setTheme(next);
-            }}
-          />
-        </div>
-      )}
-
-      {profileOpen && (
+      {openPanel === "user-settings" && (
         <div className="absolute bottom-3 left-20 z-10 w-80 pl-2">
-          <ProfileEditor />
-        </div>
-      )}
-
-      {inviteOpen && canManageInvites && (
-        <div className="absolute bottom-3 left-20 z-10 w-104 pl-2">
           <div className="grid gap-3">
-            <CreateInviteDialog
-              roles={roles}
-              onCreate={async (input) => {
-                if (!address || !token) {
-                  throw new Error("Not connected");
-                }
-                const created = await createInvite(address, token, input);
-                await refreshInvites();
-                return created;
-              }}
-            />
-            <InviteList
-              invites={invites}
-              loading={loadingInvites}
-              onRevoke={async (code) => {
-                if (!address || !token) {
-                  throw new Error("Not connected");
-                }
-                await revokeInvite(address, token, code);
-                await refreshInvites();
+            <ProfileEditor />
+            <ThemeSwitcher
+              theme={theme}
+              onThemeSelect={(next) => {
+                setTheme(next);
               }}
             />
           </div>
         </div>
       )}
 
-      {membersOpen && (
-        <div className="absolute bottom-3 left-20 z-10 w-lg pl-2">
+      {openPanel === "server-settings" && showServerSettings && (
+        <div className="absolute bottom-3 left-20 z-10 w-104 pl-2">
           <div className="grid gap-3">
             <MembershipSettings mode="server-config" />
-            <MemberList
-              members={members}
-              onKick={async (pubkey) => {
-                if (!address || !token) {
-                  throw new Error("Not connected");
-                }
-                await kickMember(address, token, pubkey);
-              }}
-              onBan={async (pubkey, reason) => {
-                if (!address || !token) {
-                  throw new Error("Not connected");
-                }
-                await banMember(address, token, pubkey, reason);
-              }}
-            />
+            {canManageInvites && (
+              <>
+                <CreateInviteDialog
+                  roles={roles}
+                  onCreate={async (input) => {
+                    if (!address || !token) {
+                      throw new Error("Not connected");
+                    }
+                    const created = await createInvite(address, token, input);
+                    await fetchInvites(address, token);
+                    return created;
+                  }}
+                />
+                <InviteList
+                  invites={invites}
+                  loading={loadingInvites}
+                  onRevoke={async (code) => {
+                    if (!address || !token) {
+                      throw new Error("Not connected");
+                    }
+                    await revokeInvite(address, token, code);
+                    await fetchInvites(address, token);
+                  }}
+                />
+              </>
+            )}
             {canBanMembers && (
               <BanList
                 bans={bans}

--- a/client/src/components/members/MemberList.tsx
+++ b/client/src/components/members/MemberList.tsx
@@ -23,26 +23,26 @@ export function MemberList({ members, onKick, onBan }: MemberListProps) {
   });
 
   return (
-    <section className="rounded-xl border border-ctp-overlay0 bg-ctp-mantle/90 p-3">
+    <section className="p-3">
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-bold text-ctp-text">Members</h3>
         <span className="text-xs text-ctp-subtext0">{sorted.length}</span>
       </div>
-      <div className="max-h-72 space-y-2 overflow-auto pr-1">
+      <div className="space-y-2">
         {sorted.map((member) => (
           <div
             key={member.user_id}
             className="rounded-lg border border-ctp-surface1 bg-ctp-base/70 p-2"
           >
             <div className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 min-w-0">
                 <Avatar pubkey={member.pubkey} avatarHash={member.avatar_hash} size={28} />
-                <div>
-                  <div className="text-sm font-semibold text-ctp-text">
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold text-ctp-text truncate">
                     {member.display_name ?? truncatePubkey(member.pubkey)}
                   </div>
                   {member.display_name && (
-                    <div className="text-xs text-ctp-subtext0">{truncatePubkey(member.pubkey)}</div>
+                    <div className="text-xs text-ctp-subtext0 truncate">{truncatePubkey(member.pubkey)}</div>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
Closes #35

## Summary
Consolidates sidebar menu icons into two logical groups (User Settings and Server Settings) and relocates the member list from a sidebar popup to a persistent right-side panel in the main chat view.

## Changes
- **ServerSidebar**: Replaced 4 individual icons (INV, 👥, 👤, ⚙) with 2 consolidated menus:
  - **User Settings** (👤): Profile editor + Theme switcher
  - **Server Settings** (⚙): Membership settings, Invites, Ban list, Allowlist
- **Permission gating**: Server Settings button only visible if user has MANAGE_INVITES, BAN_MEMBERS, MANAGE_SERVER, or MANAGE_ROLES
- **AppShell**: Added right-side member panel (`w-64`) with auto-fetch on connect
- **MessageView**: Added 👥 toggle button in channel header to show/hide member panel
- **MemberList**: Restyled for full-height panel layout (removed max-h constraint, added truncation for narrow panel)

## Testing
- All existing tests pass (88 Rust, 17 frontend)
- cargo clippy -- -D warnings: clean
- pnpm lint: clean (pre-existing warning in App.tsx unrelated to changes)