### PR TITLE
Fix window control buttons

### DIFF
--- a/client/src-tauri/capabilities/default.json
+++ b/client/src-tauri/capabilities/default.json
@@ -6,6 +6,12 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "deep-link:default"
+    "deep-link:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-maximize",
+    "core:window:allow-unmaximize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-start-dragging"
   ]
 }

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -12,6 +12,7 @@
   "app": {
     "windows": [
       {
+        "label": "main",
         "title": "decentcom",
         "width": 1200,
         "height": 800,

--- a/client/src/components/layout/TitleBar.test.tsx
+++ b/client/src/components/layout/TitleBar.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  isMaximized: vi.fn().mockResolvedValue(false),
+  onResized: vi.fn().mockResolvedValue(vi.fn()),
+  minimize: vi.fn(),
+  toggleMaximize: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => hoisted,
+}));
+
+// Import TitleBar AFTER the mock is set up
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TitleBar } from "./TitleBar";
+
+describe("TitleBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders with correct title", () => {
+    render(<TitleBar />);
+    expect(screen.getByText("decentcom")).toBeInTheDocument();
+  });
+
+  it("calls minimize when minimize button is clicked", () => {
+    render(<TitleBar />);
+    const minimizeBtn = screen.getByTitle("Minimize");
+    fireEvent.click(minimizeBtn);
+    expect(hoisted.minimize).toHaveBeenCalled();
+  });
+
+  it("calls toggleMaximize when maximize button is clicked", () => {
+    render(<TitleBar />);
+    const maximizeBtn = screen.getByTitle("Maximize");
+    fireEvent.click(maximizeBtn);
+    expect(hoisted.toggleMaximize).toHaveBeenCalled();
+  });
+
+  it("calls close when close button is clicked", () => {
+    render(<TitleBar />);
+    const closeBtn = screen.getByTitle("Close");
+    fireEvent.click(closeBtn);
+    expect(hoisted.close).toHaveBeenCalled();
+  });
+
+  it("buttons have data-tauri-no-drag attribute", () => {
+    render(<TitleBar />);
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach(button => {
+      expect(button).toHaveAttribute("data-tauri-no-drag");
+    });
+  });
+
+  it("renders Maximize title when not maximized", async () => {
+    hoisted.isMaximized.mockResolvedValue(false);
+    render(<TitleBar />);
+    expect(screen.getByTitle("Maximize")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/layout/TitleBar.tsx
+++ b/client/src/components/layout/TitleBar.tsx
@@ -42,6 +42,7 @@ export function TitleBar() {
       <div className="flex items-center h-full">
         <button
           onClick={handleMinimize}
+          data-tauri-no-drag
           className="w-12 h-full flex items-center justify-center hover:bg-ctp-surface0 transition-colors text-ctp-text"
           title="Minimize"
         >
@@ -51,6 +52,7 @@ export function TitleBar() {
         </button>
         <button
           onClick={handleMaximize}
+          data-tauri-no-drag
           className="w-12 h-full flex items-center justify-center hover:bg-ctp-surface0 transition-colors text-ctp-text"
           title={isMaximized ? "Restore" : "Maximize"}
         >
@@ -82,6 +84,7 @@ export function TitleBar() {
         </button>
         <button
           onClick={handleClose}
+          data-tauri-no-drag
           className="w-12 h-full flex items-center justify-center hover:bg-ctp-red hover:text-ctp-crust transition-colors text-ctp-text"
           title="Close"
         >


### PR DESCRIPTION
Fixes #38. Added missing permissions and improved Wayland compatibility for window controls.