### PR TITLE
feat: automatic connection retries and enhanced UI recovery (#36)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,6 +34,13 @@ function App() {
     initTheme();
   }, [initTheme]);
 
+  // Clear connection errors once the gateway is connected
+  useEffect(() => {
+    if (status === "connected") {
+      setConnectError(null);
+    }
+  }, [status]);
+
   useEffect(() => {
     if (
       hasIdentity &&

--- a/client/src/components/connection/StatusIndicator.tsx
+++ b/client/src/components/connection/StatusIndicator.tsx
@@ -1,4 +1,4 @@
-type Status = "connecting" | "connected" | "disconnected";
+type Status = "connecting" | "connected" | "disconnected" | "reconnecting";
 
 interface StatusIndicatorProps {
   status: Status;
@@ -7,6 +7,7 @@ interface StatusIndicatorProps {
 const STATUS_STYLES: Record<Status, string> = {
   connected: "bg-ctp-green/20 text-ctp-green border-ctp-green/40",
   connecting: "bg-ctp-yellow/20 text-ctp-yellow border-ctp-yellow/40",
+  reconnecting: "bg-ctp-yellow/20 text-ctp-yellow border-ctp-yellow/40",
   disconnected: "bg-ctp-red/20 text-ctp-red border-ctp-red/40",
 };
 
@@ -15,7 +16,7 @@ export function StatusIndicator({ status }: StatusIndicatorProps) {
     <span
       className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold uppercase tracking-wide ${STATUS_STYLES[status]}`}
     >
-      {status}
+      {status === "reconnecting" ? "reconnecting…" : status}
     </span>
   );
 }

--- a/client/src/services/gateway.ts
+++ b/client/src/services/gateway.ts
@@ -16,10 +16,16 @@ function toGatewayUrl(baseUrl: string): string {
   return `${baseUrl}/api/v1/gateway`;
 }
 
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30000;
+const BACKOFF_FACTOR = 2;
+
 export class GatewayClient {
   private socket: WebSocket | null = null;
   private reconnectTimer: number | null = null;
   private shouldReconnect = true;
+  private reconnectAttempt = 0;
+  private wasConnected = false;
   private readonly getState: () => ServerStore;
 
   constructor(getState: () => ServerStore) {
@@ -36,13 +42,25 @@ export class GatewayClient {
       return;
     }
 
+    if (this.reconnectAttempt > 0) {
+      this.getState().setStatus("reconnecting");
+    }
+
     const url = new URL(toGatewayUrl(state.address));
     url.searchParams.set("token", state.sessionToken);
 
     this.socket = new WebSocket(url.toString());
 
     this.socket.onopen = () => {
+      const wasReconnect = this.wasConnected;
+      this.reconnectAttempt = 0;
+      this.wasConnected = true;
       this.getState().setStatus("connected");
+
+      if (wasReconnect) {
+        void this.getState().revalidate();
+      }
+
       const channelId = this.getState().currentChannelId;
       if (channelId) {
         this.subscribe(channelId);
@@ -63,20 +81,24 @@ export class GatewayClient {
     };
 
     this.socket.onclose = () => {
-      this.getState().setStatus("disconnected");
       this.socket = null;
       if (this.shouldReconnect) {
+        this.getState().setStatus("reconnecting");
         this.scheduleReconnect();
+      } else {
+        this.getState().setStatus("disconnected");
       }
     };
 
     this.socket.onerror = () => {
-      this.getState().setStatus("disconnected");
+      // onerror is always followed by onclose, so no status change needed here.
     };
   }
 
   disconnect() {
     this.shouldReconnect = false;
+    this.reconnectAttempt = 0;
+    this.wasConnected = false;
     if (this.reconnectTimer !== null) {
       window.clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -87,6 +109,7 @@ export class GatewayClient {
 
   reconnect() {
     this.shouldReconnect = true;
+    this.reconnectAttempt = 0;
     this.connect();
   }
 
@@ -109,9 +132,11 @@ export class GatewayClient {
     if (this.reconnectTimer !== null) {
       return;
     }
+    const delay = Math.min(BASE_DELAY_MS * BACKOFF_FACTOR ** this.reconnectAttempt, MAX_DELAY_MS);
+    this.reconnectAttempt += 1;
     this.reconnectTimer = window.setTimeout(() => {
       this.reconnectTimer = null;
       this.connect();
-    }, 1500);
+    }, delay);
   }
 }

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -37,7 +37,7 @@ interface MessagePage {
   has_more: boolean;
 }
 
-type ConnectionStatus = "connecting" | "connected" | "disconnected";
+type ConnectionStatus = "connecting" | "connected" | "disconnected" | "reconnecting";
 
 export interface GatewayEvent {
   op: string;
@@ -73,6 +73,7 @@ export interface ServerStore {
 
   connect: (address: string) => Promise<void>;
   disconnect: () => void;
+  revalidate: () => Promise<void>;
   setCurrentChannel: (id: string) => Promise<void>;
   sendMessage: (content: string) => Promise<void>;
   loadMoreMessages: (channelId: string) => Promise<void>;
@@ -191,6 +192,33 @@ export const useServerStore = create<ServerStore>((set, get) => ({
       messages: {},
       hasMore: {},
     });
+  },
+
+  revalidate: async () => {
+    const { address, sessionToken } = get();
+    if (!address || !sessionToken) return;
+
+    try {
+      const channelData = await apiRequest<ChannelsResponse>(address, "/api/v1/channels", {
+        token: sessionToken,
+      });
+      const roleData = await listRoles(address, sessionToken);
+      await useMembersStore.getState().fetchMembers(address, sessionToken);
+
+      const members = useMembersStore.getState().members;
+      const roleMap: Record<string, string[]> = {};
+      for (const member of members) {
+        roleMap[member.user_id] = member.roles.map((r) => r.id);
+      }
+
+      set({
+        channels: sortChannels(channelData.channels),
+        roles: roleData,
+        memberRoleIdsByUserId: roleMap,
+      });
+    } catch {
+      // Revalidation is best-effort; the gateway is already connected.
+    }
   },
 
   setCurrentChannel: async (id: string) => {


### PR DESCRIPTION
Closes #36

## Summary
Implements robust retry logic for WebSocket reconnection with exponential backoff, re-fetches server metadata on reconnect, clears error states on successful recovery, and adds a visual "reconnecting" indicator.

## Changes
- **GatewayClient**: Exponential backoff (1s → 2s → 4s → ... → 30s cap) replaces fixed 1.5s retry. Resets on successful connect. Tracks `wasConnected` to distinguish initial connect from reconnect.
- **GatewayClient onclose**: Sets status to `reconnecting` (not `disconnected`) when auto-reconnect is active, preventing App.tsx auto-connect from conflicting with the gateway's own retry.
- **GatewayClient onopen**: Calls `revalidate()` on reconnection to refresh metadata that may have changed while offline.
- **ServerStore**: New `reconnecting` connection status and `revalidate()` action that re-fetches channels, roles, and members without a full disconnect/connect cycle.
- **App.tsx**: New `useEffect` clears `connectError` when status becomes `connected`.
- **StatusIndicator**: Displays `reconnecting…` with yellow styling.

## Testing
- All existing tests pass (88 Rust, 23 frontend)
- cargo clippy -- -D warnings: clean
- pnpm lint: clean (pre-existing warning in App.tsx unrelated to changes)