### PR TITLE
fix: persist profile changes and consolidate theme storage (#41)

### DIFF
--- a/client/src/components/profile/ProfileEditor.tsx
+++ b/client/src/components/profile/ProfileEditor.tsx
@@ -9,6 +9,7 @@ export function ProfileEditor() {
   const token = useServerStore((s) => s.sessionToken);
   const userId = useServerStore((s) => s.sessionUserId);
   const member = useMembersStore((s) => s.members.find((m) => m.user_id === userId));
+  const updateMemberProfile = useMembersStore((s) => s.updateMemberProfile);
 
   const [displayName, setDisplayName] = useState(member?.display_name ?? "");
   const [saving, setSaving] = useState(false);
@@ -18,14 +19,17 @@ export function ProfileEditor() {
   const fileRef = useRef<HTMLInputElement>(null);
 
   async function handleSaveDisplayName() {
-    if (!token) return;
+    if (!token || !userId) return;
     setSaving(true);
     setError(null);
     setSuccess(null);
     try {
       const trimmed = displayName.trim();
-      await updateProfile(address, token, {
+      const updated = await updateProfile(address, token, {
         display_name: trimmed || undefined,
+      });
+      updateMemberProfile(userId, {
+        display_name: updated.display_name ?? null,
       });
       setSuccess("Display name updated");
     } catch (err) {
@@ -36,12 +40,15 @@ export function ProfileEditor() {
   }
 
   async function handleUploadAvatar(file: File) {
-    if (!token) return;
+    if (!token || !userId) return;
     setUploading(true);
     setError(null);
     setSuccess(null);
     try {
-      await uploadAvatar(address, token, file);
+      const updated = await uploadAvatar(address, token, file);
+      updateMemberProfile(userId, {
+        avatar_hash: updated.avatar_hash ?? null,
+      });
       setSuccess("Avatar updated");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -51,12 +58,13 @@ export function ProfileEditor() {
   }
 
   async function handleDeleteAvatar() {
-    if (!token) return;
+    if (!token || !userId) return;
     setUploading(true);
     setError(null);
     setSuccess(null);
     try {
       await deleteAvatar(address, token);
+      updateMemberProfile(userId, { avatar_hash: null });
       setSuccess("Avatar removed");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));

--- a/client/src/stores/appStore.ts
+++ b/client/src/stores/appStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-import { applyTheme, defaultTheme, loadTheme, saveTheme } from "../theme/apply";
+import { applyTheme, defaultTheme } from "../theme/apply";
 import type { ThemeName } from "../theme/types";
 
 export interface ServerConnection {
@@ -73,13 +73,11 @@ export const useAppStore = create<AppStore>()(
       setCurrentServer: (id) => set({ currentServerId: id }),
       setTheme: (theme) => {
         applyTheme(theme);
-        saveTheme(theme);
         set({ theme });
       },
       initTheme: () => {
-        const theme = loadTheme();
+        const theme = get().theme;
         applyTheme(theme);
-        set({ theme });
       },
     }),
     {

--- a/client/src/stores/members.ts
+++ b/client/src/stores/members.ts
@@ -28,6 +28,10 @@ interface MembersStore {
   unban: (baseUrl: string, token: string, pubkey: string) => Promise<void>;
   addAllowlistEntry: (baseUrl: string, token: string, pubkey: string) => Promise<void>;
   removeAllowlistEntry: (baseUrl: string, token: string, pubkey: string) => Promise<void>;
+  updateMemberProfile: (
+    userId: string,
+    patch: { display_name?: string | null; avatar_hash?: string | null },
+  ) => void;
   applyGatewayEvent: (event: { op: string; d: unknown }) => void;
   clear: () => void;
 }
@@ -97,6 +101,20 @@ export const useMembersStore = create<MembersStore>((set) => ({
   removeAllowlistEntry: async (baseUrl, token, pubkey) => {
     await removeAllowlist(baseUrl, token, pubkey);
     set((state) => ({ allowlist: state.allowlist.filter((entry) => entry.pubkey !== pubkey) }));
+  },
+
+  updateMemberProfile: (userId, patch) => {
+    set((state) => ({
+      members: state.members.map((member) =>
+        member.user_id === userId
+          ? {
+              ...member,
+              ...(patch.display_name !== undefined ? { display_name: patch.display_name } : {}),
+              ...(patch.avatar_hash !== undefined ? { avatar_hash: patch.avatar_hash } : {}),
+            }
+          : member,
+      ),
+    }));
   },
 
   applyGatewayEvent: (event) => {

--- a/client/src/theme/apply.test.ts
+++ b/client/src/theme/apply.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { CATPPUCCIN } from "./colors";
-import { applyTheme, loadTheme, saveTheme } from "./apply";
+import { applyTheme, defaultTheme } from "./apply";
 import { CTP_COLOR_KEYS, THEME_NAMES } from "./types";
 
 describe("theme apply", () => {
@@ -50,17 +50,7 @@ describe("theme apply", () => {
     }
   });
 
-  it("loadTheme defaults to mocha and saveTheme persists flavors", () => {
-    expect(loadTheme()).toBe("mocha");
-
-    for (const name of THEME_NAMES) {
-      saveTheme(name);
-      expect(loadTheme()).toBe(name);
-    }
-  });
-
-  it("loadTheme ignores unknown values", () => {
-    localStorage.setItem("decentcom-theme", "weird-theme");
-    expect(loadTheme()).toBe("mocha");
+  it("defaultTheme returns mocha", () => {
+    expect(defaultTheme()).toBe("mocha");
   });
 });

--- a/client/src/theme/apply.ts
+++ b/client/src/theme/apply.ts
@@ -1,7 +1,6 @@
 import { CATPPUCCIN } from "./colors";
 import { CTP_COLOR_KEYS, THEME_NAMES, ThemeName } from "./types";
 
-const THEME_STORAGE_KEY = "decentcom-theme";
 const DEFAULT_THEME: ThemeName = "mocha";
 
 export function applyTheme(theme: ThemeName): void {
@@ -17,21 +16,6 @@ export function applyTheme(theme: ThemeName): void {
 
 export function isThemeName(value: string): value is ThemeName {
   return THEME_NAMES.includes(value as ThemeName);
-}
-
-export function loadTheme(): ThemeName {
-  const raw = localStorage.getItem(THEME_STORAGE_KEY);
-  if (!raw) {
-    return DEFAULT_THEME;
-  }
-  if (!isThemeName(raw)) {
-    return DEFAULT_THEME;
-  }
-  return raw;
-}
-
-export function saveTheme(theme: ThemeName): void {
-  localStorage.setItem(THEME_STORAGE_KEY, theme);
 }
 
 export function defaultTheme(): ThemeName {


### PR DESCRIPTION
Closes #41

## Summary
Fixes two settings persistence bugs: profile edits not reflecting in the UI until page reload, and theme being dual-written to two localStorage keys causing divergence.

## Changes
- **Profile persistence**: Added `updateMemberProfile(userId, patch)` action to `useMembersStore` that optimistically updates `display_name` and `avatar_hash` for a member. `ProfileEditor` now calls this after each successful API call.
- **Theme consolidation**: Removed `saveTheme`/`loadTheme` and the manual `decentcom-theme` localStorage key from `theme/apply.ts`. Theme is now stored exclusively via zustand persist middleware in `decentcom-app-storage`. `appStore.initTheme` reads from its own persisted state.
- Updated `apply.test.ts` to remove tests for removed functions and add `defaultTheme` test.

## Testing
- All existing tests pass (88 Rust, 22 frontend)
- Updated apply.test.ts: removed loadTheme/saveTheme tests, added defaultTheme test
- cargo clippy -- -D warnings: clean
- pnpm lint: clean (pre-existing App.tsx warning only)