### PR TITLE
feat: member list context menu for moderation actions (#43)

### DIFF
--- a/client/src/api/members.ts
+++ b/client/src/api/members.ts
@@ -118,3 +118,29 @@ export async function removeAllowlist(baseUrl: string, token: string, pubkey: st
     token,
   });
 }
+
+export async function assignRole(
+  baseUrl: string,
+  token: string,
+  pubkey: string,
+  roleId: string,
+): Promise<void> {
+  await apiRequest<void>(
+    baseUrl,
+    `/api/v1/members/${encodeURIComponent(pubkey)}/roles/${encodeURIComponent(roleId)}`,
+    { method: "PUT", token },
+  );
+}
+
+export async function removeRole(
+  baseUrl: string,
+  token: string,
+  pubkey: string,
+  roleId: string,
+): Promise<void> {
+  await apiRequest<void>(
+    baseUrl,
+    `/api/v1/members/${encodeURIComponent(pubkey)}/roles/${encodeURIComponent(roleId)}`,
+    { method: "DELETE", token },
+  );
+}

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { assignRole, removeRole } from "../../api/members";
 import { useAppStore } from "../../stores/appStore";
 import { useMembersStore } from "../../stores/members";
 import { useServerStore } from "../../stores/serverStore";
@@ -18,6 +19,8 @@ export function AppShell() {
     messages,
     hasMore,
     status,
+    roles,
+    memberRoleIdsByUserId,
     setCurrentChannel,
     sendMessage,
     loadMoreMessages,
@@ -51,6 +54,22 @@ export function AppShell() {
       await banMember(address, sessionToken, pubkey, reason);
     },
     [address, sessionToken, banMember],
+  );
+
+  const handleAssignRole = useCallback(
+    async (pubkey: string, roleId: string) => {
+      if (!address || !sessionToken) throw new Error("Not connected");
+      await assignRole(address, sessionToken, pubkey, roleId);
+    },
+    [address, sessionToken],
+  );
+
+  const handleRemoveRole = useCallback(
+    async (pubkey: string, roleId: string) => {
+      if (!address || !sessionToken) throw new Error("Not connected");
+      await removeRole(address, sessionToken, pubkey, roleId);
+    },
+    [address, sessionToken],
   );
 
   const serverList = useMemo(() => Object.values(servers), [servers]);
@@ -87,7 +106,15 @@ export function AppShell() {
       />
       {memberPanelOpen && currentServerId && status === "connected" && (
         <aside className="w-64 border-l border-ctp-overlay0 bg-ctp-mantle overflow-y-auto shrink-0">
-          <MemberList members={members} onKick={handleKick} onBan={handleBan} />
+          <MemberList
+            members={members}
+            roles={roles}
+            memberRoleIdsByUserId={memberRoleIdsByUserId}
+            onKick={handleKick}
+            onBan={handleBan}
+            onAssignRole={handleAssignRole}
+            onRemoveRole={handleRemoveRole}
+          />
         </aside>
       )}
     </main>

--- a/client/src/components/members/MemberContextMenu.test.tsx
+++ b/client/src/components/members/MemberContextMenu.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  permissionBits: 0,
+}));
+
+vi.mock("../../hooks/usePermissions", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    usePermissions: () => ({
+      bits: hoisted.permissionBits,
+      has: (perm: number) => (hoisted.permissionBits & perm) === perm,
+    }),
+  };
+});
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemberContextMenu } from "./MemberContextMenu";
+import { KICK_MEMBERS, BAN_MEMBERS, MANAGE_ROLES } from "../../hooks/usePermissions";
+import type { Member } from "../../api/members";
+import type { Role } from "../../api/roles";
+
+const baseMember: Member = {
+  user_id: "u1",
+  pubkey: "pk1",
+  display_name: "Alice",
+  avatar_hash: null,
+  joined_at: "2025-01-01T00:00:00Z",
+  roles: [],
+};
+
+const mockRoles: Role[] = [
+  { id: "everyone", name: "@everyone", color: null, permissions: 0, position: 0, is_builtin: true, created_at: "", updated_at: "" },
+  { id: "admin", name: "@admin", color: null, permissions: 0, position: 100, is_builtin: true, created_at: "", updated_at: "" },
+  { id: "mod", name: "Moderator", color: "#ff0", permissions: 0, position: 50, is_builtin: false, created_at: "", updated_at: "" },
+  { id: "vip", name: "VIP", color: "#0ff", permissions: 0, position: 10, is_builtin: false, created_at: "", updated_at: "" },
+];
+
+const noop = async () => {};
+
+describe("MemberContextMenu", () => {
+  beforeEach(() => {
+    hoisted.permissionBits = 0;
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when user has no permissions", () => {
+    const { container } = render(
+      <MemberContextMenu
+        member={baseMember}
+        roles={mockRoles}
+        memberRoleIds={[]}
+        onKick={noop}
+        onBan={noop}
+        onAssignRole={noop}
+        onRemoveRole={noop}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders ⋯ button and no inline Kick/Ban buttons", () => {
+    hoisted.permissionBits = KICK_MEMBERS | BAN_MEMBERS;
+    render(
+      <MemberContextMenu
+        member={baseMember}
+        roles={mockRoles}
+        memberRoleIds={[]}
+        onKick={noop}
+        onBan={noop}
+        onAssignRole={noop}
+        onRemoveRole={noop}
+      />,
+    );
+    expect(screen.getByLabelText("Member actions")).toBeInTheDocument();
+    // No inline Kick/Ban buttons visible before opening menu
+    expect(screen.queryByText("Kick")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ban")).not.toBeInTheDocument();
+  });
+
+  it("opens menu on ⋯ click and closes on outside click", () => {
+    hoisted.permissionBits = KICK_MEMBERS;
+    render(
+      <MemberContextMenu
+        member={baseMember}
+        roles={mockRoles}
+        memberRoleIds={[]}
+        onKick={noop}
+        onBan={noop}
+        onAssignRole={noop}
+        onRemoveRole={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Member actions"));
+    expect(screen.getByText("Kick")).toBeInTheDocument();
+
+    // Outside click closes menu
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("Kick")).not.toBeInTheDocument();
+  });
+
+  it("hides Kick/Ban items when user lacks corresponding permission", () => {
+    // Only MANAGE_ROLES, no kick or ban
+    hoisted.permissionBits = MANAGE_ROLES;
+    render(
+      <MemberContextMenu
+        member={baseMember}
+        roles={mockRoles}
+        memberRoleIds={[]}
+        onKick={noop}
+        onBan={noop}
+        onAssignRole={noop}
+        onRemoveRole={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Member actions"));
+    expect(screen.queryByText("Kick")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ban")).not.toBeInTheDocument();
+    // But roles section is present
+    expect(screen.getByText("Roles")).toBeInTheDocument();
+  });
+
+  it("hides role toggle section when user lacks MANAGE_ROLES", () => {
+    hoisted.permissionBits = KICK_MEMBERS | BAN_MEMBERS;
+    render(
+      <MemberContextMenu
+        member={baseMember}
+        roles={mockRoles}
+        memberRoleIds={[]}
+        onKick={noop}
+        onBan={noop}
+        onAssignRole={noop}
+        onRemoveRole={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Member actions"));
+    expect(screen.getByText("Kick")).toBeInTheDocument();
+    expect(screen.getByText("Ban")).toBeInTheDocument();
+    expect(screen.queryByText("Roles")).not.toBeInTheDocument();
+    expect(screen.queryByText("Moderator")).not.toBeInTheDocument();
+  });
+
+  it("shows role toggles with checkmarks for assigned roles", () => {
+    hoisted.permissionBits = MANAGE_ROLES;
+    render(
+      <MemberContextMenu
+        member={baseMember}
+        roles={mockRoles}
+        memberRoleIds={["mod"]}
+        onKick={noop}
+        onBan={noop}
+        onAssignRole={noop}
+        onRemoveRole={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Member actions"));
+    // Non-builtin roles appear
+    expect(screen.getByText("Moderator")).toBeInTheDocument();
+    expect(screen.getByText("VIP")).toBeInTheDocument();
+    // Builtin roles do not appear as toggles
+    expect(screen.queryByText("@everyone")).not.toBeInTheDocument();
+    expect(screen.queryByText("@admin")).not.toBeInTheDocument();
+    // Checkmark for assigned role
+    expect(screen.getByText("✓")).toBeInTheDocument();
+  });
+
+  it("shows kick confirmation on Kick click", () => {
+    hoisted.permissionBits = KICK_MEMBERS;
+    render(
+      <MemberContextMenu
+        member={baseMember}
+        roles={mockRoles}
+        memberRoleIds={[]}
+        onKick={noop}
+        onBan={noop}
+        onAssignRole={noop}
+        onRemoveRole={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Member actions"));
+    fireEvent.click(screen.getByText("Kick"));
+    expect(screen.getByText("Kick this member?")).toBeInTheDocument();
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+  });
+
+  it("shows ban reason input on Ban click", () => {
+    hoisted.permissionBits = BAN_MEMBERS;
+    render(
+      <MemberContextMenu
+        member={baseMember}
+        roles={mockRoles}
+        memberRoleIds={[]}
+        onKick={noop}
+        onBan={noop}
+        onAssignRole={noop}
+        onRemoveRole={noop}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Member actions"));
+    fireEvent.click(screen.getByText("Ban"));
+    expect(screen.getByText("Ban this member?")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Reason (optional)")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/members/MemberContextMenu.tsx
+++ b/client/src/components/members/MemberContextMenu.tsx
@@ -1,67 +1,243 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { Member } from "../../api/members";
-import { BAN_MEMBERS, KICK_MEMBERS, usePermissions } from "../../hooks/usePermissions";
+import type { Role } from "../../api/roles";
+import { BAN_MEMBERS, KICK_MEMBERS, MANAGE_ROLES, usePermissions } from "../../hooks/usePermissions";
 
 interface MemberContextMenuProps {
   member: Member;
+  roles: Role[];
+  memberRoleIds: string[];
   onKick: (pubkey: string) => Promise<void>;
   onBan: (pubkey: string, reason?: string) => Promise<void>;
+  onAssignRole: (pubkey: string, roleId: string) => Promise<void>;
+  onRemoveRole: (pubkey: string, roleId: string) => Promise<void>;
 }
 
-export function MemberContextMenu({ member, onKick, onBan }: MemberContextMenuProps) {
+type MenuView = "main" | "kick-confirm" | "ban-confirm";
+
+export function MemberContextMenu({
+  member,
+  roles,
+  memberRoleIds,
+  onKick,
+  onBan,
+  onAssignRole,
+  onRemoveRole,
+}: MemberContextMenuProps) {
   const permissions = usePermissions();
   const canKick = permissions.has(KICK_MEMBERS);
   const canBan = permissions.has(BAN_MEMBERS);
-  const [pending, setPending] = useState(false);
+  const canManageRoles = permissions.has(MANAGE_ROLES);
 
-  async function handleKick() {
-    if (!canKick || pending) {
-      return;
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<MenuView>("main");
+  const [pending, setPending] = useState(false);
+  const [banReason, setBanReason] = useState("");
+  const [pendingRoleId, setPendingRoleId] = useState<string | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const hasAnyPermission = canKick || canBan || canManageRoles;
+
+  // Non-builtin, non-everyone roles available for assignment
+  const assignableRoles = roles.filter(
+    (r) => !r.is_builtin && r.name !== "@everyone",
+  );
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setOpen(false);
+        setView("main");
+        setBanReason("");
+      }
     }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+        setView("main");
+        setBanReason("");
+      }
+    }
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [open]);
+
+  if (!hasAnyPermission) return null;
+
+  function handleToggle() {
+    setOpen((v) => !v);
+    setView("main");
+    setBanReason("");
+  }
+
+  async function handleKickConfirm() {
+    if (pending) return;
     setPending(true);
     try {
       await onKick(member.pubkey);
+      setOpen(false);
+      setView("main");
     } finally {
       setPending(false);
     }
   }
 
-  async function handleBan() {
-    if (!canBan || pending) {
-      return;
-    }
+  async function handleBanConfirm() {
+    if (pending) return;
     setPending(true);
     try {
-      await onBan(member.pubkey);
+      await onBan(member.pubkey, banReason || undefined);
+      setOpen(false);
+      setView("main");
+      setBanReason("");
     } finally {
       setPending(false);
+    }
+  }
+
+  async function handleRoleToggle(roleId: string) {
+    if (pendingRoleId) return;
+    const hasRole = memberRoleIds.includes(roleId);
+    setPendingRoleId(roleId);
+    try {
+      if (hasRole) {
+        await onRemoveRole(member.pubkey, roleId);
+      } else {
+        await onAssignRole(member.pubkey, roleId);
+      }
+    } finally {
+      setPendingRoleId(null);
     }
   }
 
   return (
-    <div className="flex gap-2">
-      {canKick && (
-        <button
-          onClick={() => {
-            void handleKick();
-          }}
-          disabled={pending}
-          className="rounded-md border border-ctp-yellow/50 bg-ctp-yellow/10 px-2 py-1 text-xs text-ctp-yellow hover:bg-ctp-yellow/20 disabled:opacity-60"
-        >
-          Kick
-        </button>
-      )}
-      {canBan && (
-        <button
-          onClick={() => {
-            void handleBan();
-          }}
-          disabled={pending}
-          className="rounded-md border border-ctp-red/50 bg-ctp-red/10 px-2 py-1 text-xs text-ctp-red hover:bg-ctp-red/20 disabled:opacity-60"
-        >
-          Ban
-        </button>
+    <div ref={menuRef} className="relative">
+      <button
+        onClick={handleToggle}
+        className="rounded-md px-1.5 py-0.5 text-ctp-subtext0 hover:bg-ctp-surface0 hover:text-ctp-text"
+        aria-label="Member actions"
+      >
+        ⋯
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-48 rounded-lg border border-ctp-surface1 bg-ctp-surface0 py-1 shadow-lg">
+          {view === "main" && (
+            <>
+              {canKick && (
+                <button
+                  onClick={() => setView("kick-confirm")}
+                  className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-ctp-yellow hover:bg-ctp-surface1"
+                >
+                  Kick
+                </button>
+              )}
+              {canBan && (
+                <button
+                  onClick={() => setView("ban-confirm")}
+                  className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-ctp-red hover:bg-ctp-surface1"
+                >
+                  Ban
+                </button>
+              )}
+              {canManageRoles && assignableRoles.length > 0 && (
+                <>
+                  {(canKick || canBan) && (
+                    <div className="mx-2 my-1 border-t border-ctp-overlay0" />
+                  )}
+                  <div className="px-3 py-1 text-xs font-semibold text-ctp-subtext0">
+                    Roles
+                  </div>
+                  {assignableRoles.map((role) => {
+                    const hasRole = memberRoleIds.includes(role.id);
+                    const isLoading = pendingRoleId === role.id;
+                    return (
+                      <button
+                        key={role.id}
+                        onClick={() => void handleRoleToggle(role.id)}
+                        disabled={isLoading}
+                        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-ctp-text hover:bg-ctp-surface1 disabled:opacity-60"
+                      >
+                        <span className="w-4 text-center text-xs">
+                          {isLoading ? "…" : hasRole ? "✓" : ""}
+                        </span>
+                        <span className="truncate">{role.name}</span>
+                      </button>
+                    );
+                  })}
+                </>
+              )}
+            </>
+          )}
+
+          {view === "kick-confirm" && (
+            <div className="px-3 py-2">
+              <p className="mb-2 text-xs text-ctp-subtext1">
+                Kick this member?
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => void handleKickConfirm()}
+                  disabled={pending}
+                  className="flex-1 rounded-md bg-ctp-yellow/20 px-2 py-1 text-xs text-ctp-yellow hover:bg-ctp-yellow/30 disabled:opacity-60"
+                >
+                  {pending ? "…" : "Confirm"}
+                </button>
+                <button
+                  onClick={() => setView("main")}
+                  disabled={pending}
+                  className="flex-1 rounded-md bg-ctp-surface1 px-2 py-1 text-xs text-ctp-subtext1 hover:bg-ctp-overlay0"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          {view === "ban-confirm" && (
+            <div className="px-3 py-2">
+              <p className="mb-2 text-xs text-ctp-subtext1">
+                Ban this member?
+              </p>
+              <input
+                type="text"
+                placeholder="Reason (optional)"
+                value={banReason}
+                onChange={(e) => setBanReason(e.target.value)}
+                className="mb-2 w-full rounded-md border border-ctp-surface1 bg-ctp-base px-2 py-1 text-xs text-ctp-text placeholder:text-ctp-overlay1 focus:outline-none focus:border-ctp-blue"
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={() => void handleBanConfirm()}
+                  disabled={pending}
+                  className="flex-1 rounded-md bg-ctp-red/20 px-2 py-1 text-xs text-ctp-red hover:bg-ctp-red/30 disabled:opacity-60"
+                >
+                  {pending ? "…" : "Confirm"}
+                </button>
+                <button
+                  onClick={() => {
+                    setView("main");
+                    setBanReason("");
+                  }}
+                  disabled={pending}
+                  className="flex-1 rounded-md bg-ctp-surface1 px-2 py-1 text-xs text-ctp-subtext1 hover:bg-ctp-overlay0"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/client/src/components/members/MemberList.tsx
+++ b/client/src/components/members/MemberList.tsx
@@ -1,11 +1,16 @@
 import type { Member } from "../../api/members";
+import type { Role } from "../../api/roles";
 import { MemberContextMenu } from "./MemberContextMenu";
 import { Avatar } from "../profile/Avatar";
 
 interface MemberListProps {
   members: Member[];
+  roles: Role[];
+  memberRoleIdsByUserId: Record<string, string[]>;
   onKick: (pubkey: string) => Promise<void>;
   onBan: (pubkey: string, reason?: string) => Promise<void>;
+  onAssignRole: (pubkey: string, roleId: string) => Promise<void>;
+  onRemoveRole: (pubkey: string, roleId: string) => Promise<void>;
 }
 
 function truncatePubkey(pubkey: string): string {
@@ -15,7 +20,15 @@ function truncatePubkey(pubkey: string): string {
   return `${pubkey.slice(0, 8)}...${pubkey.slice(-6)}`;
 }
 
-export function MemberList({ members, onKick, onBan }: MemberListProps) {
+export function MemberList({
+  members,
+  roles,
+  memberRoleIdsByUserId,
+  onKick,
+  onBan,
+  onAssignRole,
+  onRemoveRole,
+}: MemberListProps) {
   const sorted = [...members].sort((a, b) => {
     const roleA = a.roles[0]?.position ?? 0;
     const roleB = b.roles[0]?.position ?? 0;
@@ -46,7 +59,15 @@ export function MemberList({ members, onKick, onBan }: MemberListProps) {
                   )}
                 </div>
               </div>
-              <MemberContextMenu member={member} onKick={onKick} onBan={onBan} />
+              <MemberContextMenu
+                member={member}
+                roles={roles}
+                memberRoleIds={memberRoleIdsByUserId[member.user_id] ?? []}
+                onKick={onKick}
+                onBan={onBan}
+                onAssignRole={onAssignRole}
+                onRemoveRole={onRemoveRole}
+              />
             </div>
             <div className="mt-2 flex flex-wrap gap-1">
               {member.roles.map((role) => (


### PR DESCRIPTION
Closes #43

## Summary
Replace inline Kick/Ban buttons on each member row with a `⋯` dropdown context menu that consolidates moderation (kick, ban) and role assignment into a clean, permission-gated popover.

## Changes
- Added `assignRole` and `removeRole` API functions to `client/src/api/members.ts`
- Wired `onAssignRole`/`onRemoveRole` callbacks through `AppShell.tsx` → `MemberList.tsx`
- Rewrote `MemberContextMenu.tsx` as a dropdown popover:
  - `⋯` trigger button, absolutely-positioned panel
  - Closes on outside click (mousedown listener) and Escape key
  - **Kick** item with confirmation step (Confirm/Cancel)
  - **Ban** item with optional inline reason input and Confirm/Cancel
  - **Role toggle** section showing non-builtin roles with checkmarks
  - Menu hidden when user has no applicable permissions (KICK_MEMBERS, BAN_MEMBERS, MANAGE_ROLES)
  - Loading/disabled state while actions are pending
- Removed old inline Kick/Ban buttons

## Open Questions Resolved
- The `⋯` button is hidden entirely when the current user has no applicable permissions (kick, ban, or manage roles). This keeps the UI clean; future non-moderation actions can relax this gate.
- Role assignment relies on gateway events (`MEMBER_ROLE_ADD`/`MEMBER_ROLE_REMOVE`) for state updates rather than optimistic updates, since the server broadcasts these reliably.

## Testing
- All existing tests pass (88 Rust, 22 frontend)
- 8 new unit tests for MemberContextMenu:
  - Renders nothing without permissions
  - Renders ⋯ button with no inline Kick/Ban
  - Opens on click, closes on outside click
  - Hides Kick/Ban when lacking permission
  - Hides role section when lacking MANAGE_ROLES
  - Shows checkmarks for assigned roles, excludes builtin roles
  - Shows kick confirmation step
  - Shows ban reason input
- cargo clippy -- -D warnings: clean
- pnpm lint: clean (pre-existing App.tsx warning only)