### PR TITLE
feat: unify account creation via Setup modal (#55)

### DIFF
--- a/client/src-tauri/src/identity.rs
+++ b/client/src-tauri/src/identity.rs
@@ -70,9 +70,13 @@ fn load_accounts_index() -> Result<Vec<String>, IdentityError> {
         Ok(json) => {
             let accounts: Vec<String> =
                 serde_json::from_str(&json).unwrap_or_default();
+            eprintln!("[identity] load_accounts_index: {} accounts", accounts.len());
             Ok(accounts)
         }
-        Err(keyring::Error::NoEntry) => Ok(Vec::new()),
+        Err(keyring::Error::NoEntry) => {
+            eprintln!("[identity] load_accounts_index: no entry (empty)");
+            Ok(Vec::new())
+        }
         Err(e) => Err(IdentityError::Keyring(e.to_string())),
     }
 }
@@ -81,6 +85,7 @@ fn save_accounts_index(accounts: &[String]) -> Result<(), IdentityError> {
     let entry = Entry::new(SERVICE_NAME, ACCOUNTS_INDEX)?;
     let json = serde_json::to_string(accounts)
         .map_err(|e| IdentityError::Crypto(e.to_string()))?;
+    eprintln!("[identity] save_accounts_index: saving {} accounts", accounts.len());
     entry.set_password(&json)?;
     Ok(())
 }
@@ -123,6 +128,7 @@ fn load_account_label(pubkey: &str) -> Option<String> {
 fn inner_list_accounts() -> Result<Vec<AccountInfo>, IdentityError> {
     let accounts = load_accounts_index()?;
     let active = get_active_pubkey().ok();
+    eprintln!("[identity] list_accounts: {} accounts, active={:?}", accounts.len(), active.as_deref().map(|s| &s[..8.min(s.len())]));
     Ok(accounts
         .into_iter()
         .map(|pk| {
@@ -247,6 +253,8 @@ fn derive_and_store(mnemonic: &Mnemonic) -> Result<(String, SigningKey), Identit
     let signing_key = SigningKey::from_bytes(&seed_bytes);
     let pubkey = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
 
+    eprintln!("[identity] derive_and_store: pubkey={}", &pubkey[..8.min(pubkey.len())]);
+
     // Store seed under per-account keyring entry.
     let hex_seed = Zeroizing::new(hex::encode(seed_bytes.as_slice()));
     let entry = Entry::new(SERVICE_NAME, &seed_entry_name(&pubkey))?;
@@ -330,6 +338,8 @@ fn get_seed_for(pubkey: &str) -> Result<Zeroizing<[u8; 32]>, IdentityError> {
 fn store_seed(seed: &[u8; 32]) -> Result<String, IdentityError> {
     let signing_key = SigningKey::from_bytes(seed);
     let pubkey = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
+
+    eprintln!("[identity] store_seed: pubkey={}", &pubkey[..8.min(pubkey.len())]);
 
     let hex_seed = Zeroizing::new(hex::encode(seed));
     let entry = Entry::new(SERVICE_NAME, &seed_entry_name(&pubkey))?;

--- a/client/src-tauri/src/identity.rs
+++ b/client/src-tauri/src/identity.rs
@@ -70,11 +70,9 @@ fn load_accounts_index() -> Result<Vec<String>, IdentityError> {
         Ok(json) => {
             let accounts: Vec<String> =
                 serde_json::from_str(&json).unwrap_or_default();
-            eprintln!("[identity] load_accounts_index: {} accounts", accounts.len());
             Ok(accounts)
         }
         Err(keyring::Error::NoEntry) => {
-            eprintln!("[identity] load_accounts_index: no entry (empty)");
             Ok(Vec::new())
         }
         Err(e) => Err(IdentityError::Keyring(e.to_string())),
@@ -85,7 +83,6 @@ fn save_accounts_index(accounts: &[String]) -> Result<(), IdentityError> {
     let entry = Entry::new(SERVICE_NAME, ACCOUNTS_INDEX)?;
     let json = serde_json::to_string(accounts)
         .map_err(|e| IdentityError::Crypto(e.to_string()))?;
-    eprintln!("[identity] save_accounts_index: saving {} accounts", accounts.len());
     entry.set_password(&json)?;
     Ok(())
 }
@@ -128,7 +125,6 @@ fn load_account_label(pubkey: &str) -> Option<String> {
 fn inner_list_accounts() -> Result<Vec<AccountInfo>, IdentityError> {
     let accounts = load_accounts_index()?;
     let active = get_active_pubkey().ok();
-    eprintln!("[identity] list_accounts: {} accounts, active={:?}", accounts.len(), active.as_deref().map(|s| &s[..8.min(s.len())]));
     Ok(accounts
         .into_iter()
         .map(|pk| {
@@ -253,8 +249,6 @@ fn derive_and_store(mnemonic: &Mnemonic) -> Result<(String, SigningKey), Identit
     let signing_key = SigningKey::from_bytes(&seed_bytes);
     let pubkey = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
 
-    eprintln!("[identity] derive_and_store: pubkey={}", &pubkey[..8.min(pubkey.len())]);
-
     // Store seed under per-account keyring entry.
     let hex_seed = Zeroizing::new(hex::encode(seed_bytes.as_slice()));
     let entry = Entry::new(SERVICE_NAME, &seed_entry_name(&pubkey))?;
@@ -338,8 +332,6 @@ fn get_seed_for(pubkey: &str) -> Result<Zeroizing<[u8; 32]>, IdentityError> {
 fn store_seed(seed: &[u8; 32]) -> Result<String, IdentityError> {
     let signing_key = SigningKey::from_bytes(seed);
     let pubkey = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
-
-    eprintln!("[identity] store_seed: pubkey={}", &pubkey[..8.min(pubkey.len())]);
 
     let hex_seed = Zeroizing::new(hex::encode(seed));
     let entry = Entry::new(SERVICE_NAME, &seed_entry_name(&pubkey))?;

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -29,4 +29,22 @@ describe("App", () => {
       expect(screen.getByText("Create New Identity")).toBeInTheDocument();
     });
   });
+
+  it("does not render Setup full-screen when hasIdentity is true", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockImplementation(async (command: string) => {
+      if (command === "has_identity") return true;
+      if (command === "get_public_key") return { pubkey: "testkey123" };
+      if (command === "list_accounts")
+        return [{ pubkey: "testkey123", label: null, active: true }];
+      if (command === "ping") return "pong";
+      return null;
+    });
+
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.queryByText("Welcome")).not.toBeInTheDocument();
+      expect(screen.queryByText("Create New Identity")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -101,7 +101,10 @@ function App() {
   async function handleSwitchAccount(pubkey: string) {
     // Disconnect current session, switch backend active key, reload store.
     disconnect();
-    const oldPubkey = activeAccount;
+    // Read from the store directly rather than from a stale closure —
+    // an earlier async flow (e.g. handleSetupComplete) may have already
+    // changed the active account before this function runs.
+    const oldPubkey = useIdentityStore.getState().activeAccount;
     await setActiveAccount(pubkey);
     switchAppStoreAccount(oldPubkey, pubkey);
     await refresh();

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -99,14 +99,14 @@ function App() {
   }
 
   async function handleSwitchAccount(pubkey: string) {
-    // Disconnect current session, switch backend active key, reload store.
-    disconnect();
-    // Read from the store directly rather than from a stale closure —
-    // an earlier async flow (e.g. handleSetupComplete) may have already
-    // changed the active account before this function runs.
+    // Switch the app store BEFORE disconnecting so that when disconnect()
+    // triggers the auto-connect effect, currentServerId already reflects
+    // the target account (preventing a stale handleConnect from adding
+    // the old account's server to the new account's storage).
     const oldPubkey = useIdentityStore.getState().activeAccount;
-    await setActiveAccount(pubkey);
     switchAppStoreAccount(oldPubkey, pubkey);
+    disconnect();
+    await setActiveAccount(pubkey);
     await refresh();
   }
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,7 +31,6 @@ function App() {
   const { invite, clearInviteLink } = useInviteLink();
   const [connectLoading, setConnectLoading] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
-  const [addingAccount, setAddingAccount] = useState(false);
 
   const activeAccount = useIdentityStore((s) => s.activeAccount);
   const setActiveAccount = useIdentityStore((s) => s.setActiveAccount);
@@ -73,7 +72,6 @@ function App() {
     if (
       hasIdentity &&
       !loading &&
-      !addingAccount &&
       currentServerId &&
       status === "disconnected" &&
       !connectLoading &&
@@ -81,7 +79,7 @@ function App() {
     ) {
       handleConnect(currentServerId);
     }
-  }, [currentServerId, hasIdentity, loading, status, addingAccount, connectLoading, handleConnect]);
+  }, [currentServerId, hasIdentity, loading, status, connectLoading, handleConnect]);
 
   async function handleJoinByInvite(address: string, inviteCode: string) {
     setConnectLoading(true);
@@ -109,15 +107,8 @@ function App() {
     await refresh();
   }
 
-  function handleAddAccount() {
-    setAddingAccount(true);
-  }
-
-  async function handleAddAccountComplete() {
-    setAddingAccount(false);
+  async function handleFirstRunComplete() {
     await refresh();
-    // The newly generated/imported account is now the active one in the backend.
-    // Re-read from identityStore to get the updated pubkey.
     const newActive = useIdentityStore.getState().activeAccount;
     if (newActive) {
       switchAppStoreAccount(activeAccount, newActive);
@@ -131,14 +122,13 @@ function App() {
         <div className="animate-pulse">Loading identity...</div>
       </div>
     );
-  } else if (!hasIdentity || addingAccount) {
+  } else if (!hasIdentity) {
     content = (
       <main className="flex-1 flex items-center justify-center bg-ctp-base p-4 text-ctp-text">
         <Setup
           onGenerate={generateIdentity}
           onImport={importIdentity}
-          onComplete={() => void handleAddAccountComplete()}
-          onCancel={addingAccount ? () => setAddingAccount(false) : undefined}
+          onComplete={() => void handleFirstRunComplete()}
         />
       </main>
     );
@@ -176,7 +166,6 @@ function App() {
         )}
         <AppShell
           onSwitchAccount={handleSwitchAccount}
-          onAddAccount={handleAddAccount}
         />
       </>
     );

--- a/client/src/components/accounts/AccountSwitcher.test.tsx
+++ b/client/src/components/accounts/AccountSwitcher.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { useIdentityStore } from "../../stores/identityStore";
@@ -9,13 +9,43 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock("../../services/identity", () => ({
+  keyImport: vi.fn(),
+  keyBackupReadPubkey: vi.fn(),
+  keyExport: vi.fn(),
+  keyExportValidatePassphrase: vi.fn(),
+}));
+
+const mockGenerateIdentity = vi.fn();
+const mockImportIdentity = vi.fn();
+const mockRefresh = vi.fn();
+
+vi.mock("../../hooks/useIdentity", () => ({
+  useIdentity: () => ({
+    hasIdentity: true,
+    publicKey: "ABCDEFghij1234567890",
+    loading: false,
+    error: null,
+    generateIdentity: mockGenerateIdentity,
+    importIdentity: mockImportIdentity,
+    refresh: mockRefresh,
+    sign: vi.fn(),
+  }),
+}));
+
 describe("AccountSwitcher", () => {
   const onSwitch = vi.fn();
-  const onAdd = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockInvoke.mockReset();
+    mockRefresh.mockReset();
+    mockGenerateIdentity.mockReset();
   });
 
   function seedAccounts() {
@@ -32,25 +62,23 @@ describe("AccountSwitcher", () => {
 
   it("renders account list with labels and short pubkeys", () => {
     seedAccounts();
-    render(<AccountSwitcher onSwitchAccount={onSwitch} onAddAccount={onAdd} />);
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
 
     expect(screen.getByText(/Alice/)).toBeInTheDocument();
     expect(screen.getByText(/ABCDEF…7890/)).toBeInTheDocument();
-    // Unlabeled account shows short pubkey only
     expect(screen.getByText(/XYZWVU…4321/)).toBeInTheDocument();
   });
 
   it("shows active indicator on current account", () => {
     seedAccounts();
-    render(<AccountSwitcher onSwitchAccount={onSwitch} onAddAccount={onAdd} />);
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
 
-    // The active account has a green dot
     expect(screen.getByText("●")).toBeInTheDocument();
   });
 
   it("calls onSwitchAccount when clicking inactive account", () => {
     seedAccounts();
-    render(<AccountSwitcher onSwitchAccount={onSwitch} onAddAccount={onAdd} />);
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
 
     const inactiveButton = screen.getByText(/XYZWVU…4321/);
     fireEvent.click(inactiveButton);
@@ -60,7 +88,7 @@ describe("AccountSwitcher", () => {
 
   it("does not call onSwitchAccount when clicking active account", () => {
     seedAccounts();
-    render(<AccountSwitcher onSwitchAccount={onSwitch} onAddAccount={onAdd} />);
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
 
     const activeButton = screen.getByText(/Alice/);
     fireEvent.click(activeButton);
@@ -68,17 +96,65 @@ describe("AccountSwitcher", () => {
     expect(onSwitch).not.toHaveBeenCalled();
   });
 
-  it("calls onAddAccount when clicking add button", () => {
+  it("opens setup modal when clicking add button", () => {
     seedAccounts();
-    render(<AccountSwitcher onSwitchAccount={onSwitch} onAddAccount={onAdd} />);
+    mockInvoke.mockResolvedValue(true);
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
 
     fireEvent.click(screen.getByText("+ Add Account"));
-    expect(onAdd).toHaveBeenCalled();
+
+    expect(screen.getByText("Add Account")).toBeInTheDocument();
+    expect(screen.getByText("Create New Identity")).toBeInTheDocument();
+  });
+
+  it("closes modal on cancel without calling onSwitchAccount", () => {
+    seedAccounts();
+    mockInvoke.mockResolvedValue(true);
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
+
+    fireEvent.click(screen.getByText("+ Add Account"));
+    expect(screen.getByText("Add Account")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText("Create New Identity")).not.toBeInTheDocument();
+    expect(onSwitch).not.toHaveBeenCalled();
+  });
+
+  it("closes modal and switches account on successful creation", async () => {
+    seedAccounts();
+    const newPubkey = "NEWKEYabc12345678900";
+    mockGenerateIdentity.mockResolvedValue({
+      pubkey: newPubkey,
+      seed_phrase: Array(24).fill("word"),
+    });
+    mockRefresh.mockImplementation(async () => {
+      useIdentityStore.setState({
+        accounts: [
+          { pubkey: "ABCDEFghij1234567890", label: "Alice", active: false },
+          { pubkey: newPubkey, label: null, active: true },
+        ],
+        activeAccount: newPubkey,
+      });
+    });
+
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
+    fireEvent.click(screen.getByText("+ Add Account"));
+    fireEvent.click(screen.getByText("Create New Identity"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Secure Your Identity")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("I've saved my key — Continue"));
+
+    await waitFor(() => {
+      expect(onSwitch).toHaveBeenCalledWith(newPubkey);
+    });
   });
 
   it("shows delete confirmation on trash click", () => {
     seedAccounts();
-    render(<AccountSwitcher onSwitchAccount={onSwitch} onAddAccount={onAdd} />);
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
 
     const trashButtons = screen.getAllByTitle("Delete account");
     fireEvent.click(trashButtons[0]);
@@ -89,7 +165,7 @@ describe("AccountSwitcher", () => {
 
   it("cancels delete confirmation on No click", () => {
     seedAccounts();
-    render(<AccountSwitcher onSwitchAccount={onSwitch} onAddAccount={onAdd} />);
+    render(<AccountSwitcher onSwitchAccount={onSwitch} />);
 
     const trashButtons = screen.getAllByTitle("Delete account");
     fireEvent.click(trashButtons[0]);
@@ -101,7 +177,7 @@ describe("AccountSwitcher", () => {
   it("renders nothing when accounts list is empty", () => {
     useIdentityStore.setState({ accounts: [], activeAccount: null, loading: false, error: null });
     const { container } = render(
-      <AccountSwitcher onSwitchAccount={onSwitch} onAddAccount={onAdd} />,
+      <AccountSwitcher onSwitchAccount={onSwitch} />,
     );
     expect(container.innerHTML).toBe("");
   });

--- a/client/src/components/accounts/AccountSwitcher.tsx
+++ b/client/src/components/accounts/AccountSwitcher.tsx
@@ -1,9 +1,12 @@
 import { useState } from "react";
 import { useIdentityStore, type AccountInfo } from "../../stores/identityStore";
+import { useIdentity } from "../../hooks/useIdentity";
+import { switchAppStoreAccount } from "../../stores/appStore";
+import { Modal } from "../ui/Modal";
+import { Setup } from "../../pages/Setup";
 
 interface AccountSwitcherProps {
   onSwitchAccount: (pubkey: string) => void;
-  onAddAccount: () => void;
 }
 
 function shortPubkey(pubkey: string): string {
@@ -18,8 +21,10 @@ function displayName(account: AccountInfo): string {
   return shortPubkey(account.pubkey);
 }
 
-export function AccountSwitcher({ onSwitchAccount, onAddAccount }: AccountSwitcherProps) {
+export function AccountSwitcher({ onSwitchAccount }: AccountSwitcherProps) {
   const { accounts, activeAccount, deleteAccount, renameAccount } = useIdentityStore();
+  const { generateIdentity, importIdentity, refresh } = useIdentity();
+  const [showSetup, setShowSetup] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [editing, setEditing] = useState<string | null>(null);
   const [editLabel, setEditLabel] = useState("");
@@ -43,8 +48,29 @@ export function AccountSwitcher({ onSwitchAccount, onAddAccount }: AccountSwitch
     }
   };
 
+  const handleSetupComplete = async () => {
+    setShowSetup(false);
+    await refresh();
+    const newActive = useIdentityStore.getState().activeAccount;
+    if (newActive && newActive !== activeAccount) {
+      switchAppStoreAccount(activeAccount, newActive);
+      onSwitchAccount(newActive);
+    }
+  };
+
   return (
-    <div className="bg-ctp-mantle rounded-xl border border-ctp-overlay0 p-4 text-ctp-text">
+    <>
+      {showSetup && (
+        <Modal onClose={() => setShowSetup(false)}>
+          <Setup
+            onGenerate={generateIdentity}
+            onImport={importIdentity}
+            onComplete={() => void handleSetupComplete()}
+            onCancel={() => setShowSetup(false)}
+          />
+        </Modal>
+      )}
+      <div className="bg-ctp-mantle rounded-xl border border-ctp-overlay0 p-4 text-ctp-text">
       <h3 className="text-sm font-semibold text-ctp-subtext1 mb-2">Accounts</h3>
       <div className="space-y-1">
         {accounts.map((account: AccountInfo) => (
@@ -115,11 +141,12 @@ export function AccountSwitcher({ onSwitchAccount, onAddAccount }: AccountSwitch
         ))}
       </div>
       <button
-        onClick={onAddAccount}
+        onClick={() => setShowSetup(true)}
         className="mt-2 w-full py-2 text-sm text-ctp-subtext1 hover:text-ctp-blue hover:bg-ctp-surface0 rounded-lg transition border border-dashed border-ctp-overlay0"
       >
         + Add Account
       </button>
     </div>
+    </>
   );
 }

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -11,10 +11,9 @@ import { ServerSidebar } from "./ServerSidebar";
 
 export interface AppShellProps {
   onSwitchAccount: (pubkey: string) => void;
-  onAddAccount: () => void;
 }
 
-export function AppShell({ onSwitchAccount, onAddAccount }: AppShellProps) {
+export function AppShell({ onSwitchAccount }: AppShellProps) {
   const { currentServerId, servers, setCurrentServer } = useAppStore();
   const {
     address,
@@ -89,7 +88,6 @@ export function AppShell({ onSwitchAccount, onAddAccount }: AppShellProps) {
         currentServerId={currentServerId}
         onSelectServer={setCurrentServer}
         onSwitchAccount={onSwitchAccount}
-        onAddAccount={onAddAccount}
       />
       <ChannelSidebar
         channels={channels}

--- a/client/src/components/layout/ServerSidebar.tsx
+++ b/client/src/components/layout/ServerSidebar.tsx
@@ -82,7 +82,10 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwit
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (sidebarRef.current && !sidebarRef.current.contains(event.target as Node)) {
+      const target = event.target as HTMLElement;
+      // Ignore clicks inside portaled modals so they don't close the sidebar panel
+      if (target.closest("[data-modal-backdrop]")) return;
+      if (sidebarRef.current && !sidebarRef.current.contains(target)) {
         setOpenPanel(null);
       }
     }

--- a/client/src/components/layout/ServerSidebar.tsx
+++ b/client/src/components/layout/ServerSidebar.tsx
@@ -26,7 +26,6 @@ interface ServerSidebarProps {
   currentServerId: string | null;
   onSelectServer: (id: string) => void;
   onSwitchAccount: (pubkey: string) => void;
-  onAddAccount: () => void;
 }
 
 type OpenPanel = null | "user-settings" | "server-settings";
@@ -50,7 +49,7 @@ function initials(name: string | undefined, address: string): string {
   return name.slice(0, 2).toUpperCase();
 }
 
-export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwitchAccount, onAddAccount }: ServerSidebarProps) {
+export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwitchAccount }: ServerSidebarProps) {
   const { theme, setTheme, setCurrentServer, removeServer } = useAppStore();
   const address = useServerStore((state) => state.address);
 
@@ -192,7 +191,6 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwit
           <div className="grid gap-3">
             <AccountSwitcher
               onSwitchAccount={onSwitchAccount}
-              onAddAccount={onAddAccount}
             />
             <ProfileEditor />
             <KeyBackupPanel onImported={onSwitchAccount} />

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 interface ModalProps {
   children: ReactNode;
@@ -24,13 +25,15 @@ export function Modal({ children, onClose }: ModalProps) {
     }
   }
 
-  return (
+  return createPortal(
     <div
       ref={backdropRef}
+      data-modal-backdrop
       onClick={handleBackdropClick}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
     >
       <div className="max-h-[90vh] overflow-y-auto">{children}</div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef, type ReactNode } from "react";
+
+interface ModalProps {
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export function Modal({ children, onClose }: ModalProps) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    if (e.target === backdropRef.current) {
+      onClose();
+    }
+  }
+
+  return (
+    <div
+      ref={backdropRef}
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+    >
+      <div className="max-h-[90vh] overflow-y-auto">{children}</div>
+    </div>
+  );
+}

--- a/client/src/stores/appStore.ts
+++ b/client/src/stores/appStore.ts
@@ -126,6 +126,9 @@ export function initAppStoreForAccount(pubkey: string) {
  * Must be called AFTER the backend active account has been changed.
  */
 export function switchAppStoreAccount(oldPubkey: string | null, newPubkey: string) {
+  // Guard: nothing to do if we're already on the target account.
+  if (oldPubkey === newPubkey) return;
+
   // 1. Snapshot current state into the old account's storage key.
   if (oldPubkey) {
     const { currentServerId, servers, theme } = useAppStore.getState();


### PR DESCRIPTION
Closes #55

## Summary
Move the Add Account flow from a full-screen Setup replacement to a modal overlay within AccountSwitcher. Users can now create or import accounts without losing their current app context.

## Changes
- Create reusable `Modal` component with backdrop click + Escape key close
- `AccountSwitcher` now owns the add-account flow internally via `showSetup` state and renders `<Modal><Setup /></Modal>`
- Remove `onAddAccount` prop chain from AccountSwitcher → ServerSidebar → AppShell → App
- Remove `addingAccount` state and `handleAddAccount` from App.tsx
- First-run full-screen Setup flow is unchanged

## Testing
- All 61 existing tests pass
- New tests: modal open, cancel without side effects, successful account creation with switch
- Regression test: App does not render Setup full-screen when hasIdentity is true
- `pnpm lint`: clean