### PR TITLE
feat: implement message reactions (#19)

### DIFF
--- a/client/src/api/reactions.ts
+++ b/client/src/api/reactions.ts
@@ -1,0 +1,80 @@
+import { apiRequest } from '../services/api';
+
+export interface ReactionUser {
+  id: string;
+  display_name?: string;
+}
+
+export interface ReactionListResponse {
+  users: ReactionUser[];
+  total: number;
+}
+
+export async function addReaction(
+  baseUrl: string,
+  token: string,
+  channelId: string,
+  messageId: string,
+  emoji: string,
+): Promise<void> {
+  return apiRequest<void>(
+    baseUrl,
+    `/api/v1/channels/${channelId}/messages/${messageId}/reactions/${encodeURIComponent(emoji)}`,
+    {
+      method: 'PUT',
+      token,
+    },
+  );
+}
+
+export async function removeReaction(
+  baseUrl: string,
+  token: string,
+  channelId: string,
+  messageId: string,
+  emoji: string,
+): Promise<void> {
+  return apiRequest<void>(
+    baseUrl,
+    `/api/v1/channels/${channelId}/messages/${messageId}/reactions/${encodeURIComponent(emoji)}`,
+    {
+      method: 'DELETE',
+      token,
+    },
+  );
+}
+
+export async function removeUserReaction(
+  baseUrl: string,
+  token: string,
+  channelId: string,
+  messageId: string,
+  emoji: string,
+  userId: string,
+): Promise<void> {
+  return apiRequest<void>(
+    baseUrl,
+    `/api/v1/channels/${channelId}/messages/${messageId}/reactions/${encodeURIComponent(emoji)}/${userId}`,
+    {
+      method: 'DELETE',
+      token,
+    },
+  );
+}
+
+export async function listReactionUsers(
+  baseUrl: string,
+  token: string,
+  channelId: string,
+  messageId: string,
+  emoji: string,
+): Promise<ReactionListResponse> {
+  return apiRequest<ReactionListResponse>(
+    baseUrl,
+    `/api/v1/channels/${channelId}/messages/${messageId}/reactions/${encodeURIComponent(emoji)}`,
+    {
+      method: 'GET',
+      token,
+    },
+  );
+}

--- a/client/src/components/ReactionBar.tsx
+++ b/client/src/components/ReactionBar.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { useCallback } from 'react';
+import type { ReactionCount } from '../stores/serverStore';
+import * as reactionsApi from '../api/reactions';
+
+interface ReactionBarProps {
+  baseUrl: string;
+  channelId: string;
+  messageId: string;
+  reactions?: ReactionCount[];
+  sessionToken: string | null;
+  onReactionChange?: () => void;
+  showAddButton?: boolean;
+  onAddClick?: () => void;
+}
+
+export const ReactionBar: React.FC<ReactionBarProps> = ({
+  baseUrl,
+  channelId,
+  messageId,
+  reactions = [],
+  sessionToken,
+  onReactionChange,
+  showAddButton = false,
+  onAddClick,
+}) => {
+  const handleToggleReaction = useCallback(
+    async (emoji: string, hasReacted: boolean) => {
+      if (!sessionToken) return;
+
+      try {
+        if (hasReacted) {
+          await reactionsApi.removeReaction(baseUrl, sessionToken, channelId, messageId, emoji);
+        } else {
+          await reactionsApi.addReaction(baseUrl, sessionToken, channelId, messageId, emoji);
+        }
+        onReactionChange?.();
+      } catch (error) {
+        console.error('Failed to toggle reaction:', error);
+      }
+    },
+    [baseUrl, channelId, messageId, sessionToken, onReactionChange],
+  );
+
+  if (reactions.length === 0 && !showAddButton) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1 items-center mt-1">
+      {reactions.map((reaction) => (
+        <button
+          key={reaction.emoji}
+          onClick={() => handleToggleReaction(reaction.emoji, reaction.me)}
+          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-sm transition-colors ${
+            reaction.me
+              ? 'bg-ctp-mauve text-ctp-crust hover:bg-ctp-pink'
+              : 'bg-ctp-surface0 text-ctp-text hover:bg-ctp-surface1'
+          }`}
+          title={`${reaction.count} user${reaction.count === 1 ? '' : 's'} reacted`}
+        >
+          <span>{reaction.emoji}</span>
+          <span className="text-xs">{reaction.count}</span>
+        </button>
+      ))}
+      {showAddButton && (
+        <button
+          onClick={onAddClick}
+          className="inline-flex items-center justify-center w-6 h-6 rounded bg-ctp-surface0 text-ctp-subtext0 hover:bg-ctp-surface1 transition-colors"
+          title="Add reaction"
+        >
+          <span className="text-sm">+</span>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/client/src/components/ReactionPicker.tsx
+++ b/client/src/components/ReactionPicker.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useState } from 'react';
+
+interface ReactionPickerProps {
+  onSelect: (emoji: string) => void;
+  onClose: () => void;
+}
+
+const COMMON_EMOJIS = [
+  '👍', '👎', '😂', '🤔', '❤️', '🔥', '✨', '👌',
+  '😍', '😮', '😢', '😡', '🎉', '🚀', '💯', '👏',
+  '🙏', '👌', '💪', '🤝', '🤷', '😅', '😳', '🤗',
+];
+
+export const ReactionPicker: React.FC<ReactionPickerProps> = ({ onSelect, onClose }) => {
+  const [customEmoji, setCustomEmoji] = useState('');
+
+  const handleEmojiClick = useCallback(
+    (emoji: string) => {
+      onSelect(emoji);
+      onClose();
+    },
+    [onSelect, onClose],
+  );
+
+  const handleCustomEmojiSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (customEmoji.trim()) {
+        onSelect(customEmoji.trim());
+        onClose();
+      }
+    },
+    [customEmoji, onSelect, onClose],
+  );
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-ctp-base rounded-lg shadow-lg p-4 max-w-sm w-full mx-4">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold text-ctp-text">Add Reaction</h2>
+          <button
+            onClick={onClose}
+            className="text-ctp-subtext0 hover:text-ctp-text"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mb-4">
+          <p className="text-sm text-ctp-subtext0 mb-3">Common reactions:</p>
+          <div className="grid grid-cols-8 gap-2">
+            {COMMON_EMOJIS.map((emoji) => (
+              <button
+                key={emoji}
+                onClick={() => handleEmojiClick(emoji)}
+                className="text-2xl hover:bg-ctp-surface0 p-1 rounded transition-colors"
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="border-t border-ctp-surface0 pt-4">
+          <form onSubmit={handleCustomEmojiSubmit}>
+            <label className="block text-sm text-ctp-subtext0 mb-2">
+              Or enter a custom emoji:
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={customEmoji}
+                onChange={(e) => setCustomEmoji(e.target.value)}
+                placeholder="Enter emoji or text"
+                className="flex-1 px-3 py-2 bg-ctp-surface0 border border-ctp-surface1 rounded text-ctp-text placeholder-ctp-subtext1 focus:outline-none focus:border-ctp-mauve"
+                maxLength={10}
+              />
+              <button
+                type="submit"
+                className="px-4 py-2 bg-ctp-mauve text-ctp-crust rounded hover:bg-ctp-pink transition-colors font-medium"
+              >
+                Add
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/messages/MessageItem.test.tsx
+++ b/client/src/components/messages/MessageItem.test.tsx
@@ -16,6 +16,7 @@ describe("MessageItem", () => {
           edited_at: new Date().toISOString(),
           deleted: false,
           attachments: [],
+          reactions: [],
         }}
       />,
     );
@@ -37,6 +38,7 @@ describe("MessageItem", () => {
           edited_at: null,
           deleted: true,
           attachments: [],
+          reactions: [],
         }}
       />,
     );

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -1,7 +1,12 @@
+import { useState } from "react";
 import type { Message } from "../../stores/serverStore";
+import { useServerStore } from "../../stores/serverStore";
 import { useMembersStore } from "../../stores/members";
 import { Avatar } from "../profile/Avatar";
 import { MessageAttachment } from "./MessageAttachment";
+import { ReactionBar } from "../ReactionBar";
+import { ReactionPicker } from "../ReactionPicker";
+import * as reactionsApi from "../../api/reactions";
 
 interface MessageItemProps {
   message: Message;
@@ -22,40 +27,81 @@ function truncatePubkey(pubkey: string): string {
 }
 
 export function MessageItem({ message }: MessageItemProps) {
+  const [showPicker, setShowPicker] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
   const member = useMembersStore((s) =>
     s.members.find((m) => m.user_id === message.author_id),
   );
+  const sessionToken = useServerStore((s) => s.sessionToken);
+  const address = useServerStore((s) => s.address);
   const displayName = member?.display_name ?? (member ? truncatePubkey(member.pubkey) : message.author_id);
   const pubkey = member?.pubkey ?? message.author_id;
 
+  const handleReactionSelect = async (emoji: string) => {
+    if (!sessionToken || !address) return;
+    try {
+      await reactionsApi.addReaction(
+        address,
+        sessionToken,
+        message.channel_id,
+        message.id,
+        emoji,
+      );
+      setShowPicker(false);
+    } catch (error) {
+      console.error("Failed to add reaction:", error);
+    }
+  };
+
   return (
-    <article className="flex gap-3 rounded-lg border border-ctp-overlay0 bg-ctp-mantle/60 px-4 py-3">
-      <div className="mt-0.5 flex-shrink-0">
-        <Avatar pubkey={pubkey} avatarHash={member?.avatar_hash} size={32} />
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="mb-1 flex items-center gap-2 text-xs text-ctp-subtext0">
-          <span className="font-semibold text-ctp-subtext1">{displayName}</span>
-          <time>{formatTime(message.created_at)}</time>
-          {message.edited_at && !message.deleted && <span className="text-ctp-yellow">(edited)</span>}
+    <>
+      <article
+        className="flex gap-3 rounded-lg border border-ctp-overlay0 bg-ctp-mantle/60 px-4 py-3"
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <div className="mt-0.5 flex-shrink-0">
+          <Avatar pubkey={pubkey} avatarHash={member?.avatar_hash} size={32} />
         </div>
-        {message.deleted ? (
-          <p className="italic text-ctp-overlay1">This message was deleted.</p>
-        ) : (
-          <>
-            {message.content && (
-              <p className="whitespace-pre-wrap text-ctp-text">{message.content}</p>
-            )}
-            {message.attachments?.length > 0 && (
-              <div className="flex flex-col gap-1">
-                {message.attachments.map((a) => (
-                  <MessageAttachment key={a.id} attachment={a} />
-                ))}
-              </div>
-            )}
-          </>
-        )}
-      </div>
-    </article>
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex items-center gap-2 text-xs text-ctp-subtext0">
+            <span className="font-semibold text-ctp-subtext1">{displayName}</span>
+            <time>{formatTime(message.created_at)}</time>
+            {message.edited_at && !message.deleted && <span className="text-ctp-yellow">(edited)</span>}
+          </div>
+          {message.deleted ? (
+            <p className="italic text-ctp-overlay1">This message was deleted.</p>
+          ) : (
+            <>
+              {message.content && (
+                <p className="whitespace-pre-wrap text-ctp-text">{message.content}</p>
+              )}
+              {message.attachments?.length > 0 && (
+                <div className="flex flex-col gap-1">
+                  {message.attachments.map((a) => (
+                    <MessageAttachment key={a.id} attachment={a} />
+                  ))}
+                </div>
+              )}
+              <ReactionBar
+                baseUrl={address}
+                channelId={message.channel_id}
+                messageId={message.id}
+                reactions={message.reactions}
+                sessionToken={sessionToken}
+                showAddButton={isHovered}
+                onAddClick={() => setShowPicker(true)}
+              />
+            </>
+          )}
+        </div>
+      </article>
+      {showPicker && (
+        <ReactionPicker
+          onSelect={handleReactionSelect}
+          onClose={() => setShowPicker(false)}
+        />
+      )}
+    </>
   );
 }

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -19,6 +19,12 @@ export interface Channel {
   type: string;
 }
 
+export interface ReactionCount {
+  emoji: string;
+  count: number;
+  me: boolean;
+}
+
 export interface Message {
   id: string;
   channel_id: string;
@@ -28,6 +34,7 @@ export interface Message {
   edited_at: string | null;
   deleted: boolean;
   attachments: Attachment[];
+  reactions?: ReactionCount[];
 }
 
 interface ChannelsResponse {
@@ -53,7 +60,13 @@ export interface GatewayEvent {
     | { user_id: string; pubkey: string; left_at: string }
     | { user_id: string; pubkey: string; kicked_by: string; kicked_at: string }
     | { pubkey: string; banned_by: string; reason?: string; banned_at: string }
-    | { user_id: string; display_name?: string | null; avatar_hash?: string | null };
+    | { user_id: string; display_name?: string | null; avatar_hash?: string | null }
+    | {
+        channel_id: string;
+        message_id: string;
+        user_id: string;
+        emoji: string;
+      };
   t: number;
 }
 
@@ -465,6 +478,55 @@ export const useServerStore = create<ServerStore>((set, get) => ({
         case "MEMBER_UPDATE": {
           useMembersStore.getState().applyGatewayEvent(event);
           return {};
+        }
+        case "REACTION_ADD": {
+          const payload = event.d as {
+            channel_id: string;
+            message_id: string;
+            user_id: string;
+            emoji: string;
+          };
+          const existing = state.messages[payload.channel_id] ?? [];
+          return {
+            messages: {
+              ...state.messages,
+              [payload.channel_id]: existing.map((m) => {
+                if (m.id !== payload.message_id) return m;
+                const reactions = [...(m.reactions ?? [])];
+                const existing_reaction = reactions.find((r) => r.emoji === payload.emoji);
+                if (existing_reaction) {
+                  existing_reaction.count += 1;
+                  // Note: we don't update 'me' flag because we don't know if the current user reacted
+                  // The client should refresh or the server response will have the correct flag
+                } else {
+                  reactions.push({ emoji: payload.emoji, count: 1, me: false });
+                }
+                return { ...m, reactions };
+              }),
+            },
+          };
+        }
+        case "REACTION_REMOVE": {
+          const payload = event.d as {
+            channel_id: string;
+            message_id: string;
+            user_id: string;
+            emoji: string;
+          };
+          const existing = state.messages[payload.channel_id] ?? [];
+          return {
+            messages: {
+              ...state.messages,
+              [payload.channel_id]: existing.map((m) => {
+                if (m.id !== payload.message_id) return m;
+                const reactions = (m.reactions ?? []).map((r) => {
+                  if (r.emoji !== payload.emoji) return r;
+                  return { ...r, count: Math.max(0, r.count - 1) };
+                });
+                return { ...m, reactions: reactions.filter((r) => r.count > 0) };
+              }),
+            },
+          };
         }
         default:
           return {};

--- a/server/migrations/008_reactions.sql
+++ b/server/migrations/008_reactions.sql
@@ -1,0 +1,9 @@
+CREATE TABLE reactions (
+    message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    emoji      TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (message_id, user_id, emoji)
+);
+
+CREATE INDEX idx_reactions_message ON reactions(message_id);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -8,6 +8,7 @@ mod membership;
 mod messages;
 mod permissions;
 mod profiles;
+mod reactions;
 mod roles;
 mod server_info;
 mod storage;

--- a/server/src/messages/handlers.rs
+++ b/server/src/messages/handlers.rs
@@ -2,7 +2,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
 use serde::Serialize;
-use shared::gateway::Op;
+use shared::gateway::{Op, ReactionCount};
 
 use crate::attachments::models::AttachmentResponse;
 use crate::gateway::events::event_json;
@@ -102,6 +102,23 @@ async fn ensure_channel_exists(
     Ok(())
 }
 
+async fn enrich_message_with_reactions(
+    state: &AppState,
+    message: crate::storage::models::Message,
+    current_user_id: &str,
+) -> Result<Vec<ReactionCount>, (StatusCode, Json<ErrorBody>)> {
+    let reaction_counts = state
+        .storage
+        .count_reactions_for_message(&message.id, current_user_id)
+        .await
+        .map_err(internal)?;
+
+    Ok(reaction_counts
+        .into_iter()
+        .map(|(emoji, count, me)| ReactionCount { emoji, count, me })
+        .collect())
+}
+
 pub(super) async fn create_message(
     State(state): State<AppState>,
     auth: UserPermissions,
@@ -148,7 +165,8 @@ pub(super) async fn create_message(
         Vec::new()
     };
 
-    let response = MessageResponse::from_message(message, attachments);
+    let reactions = enrich_message_with_reactions(&state, message.clone(), &auth.user_id).await?;
+    let response = MessageResponse::from_message(message, attachments, reactions);
 
     if let Some(msg) = event_json(Op::MessageCreate, response.clone()) {
         state.gateway.broadcast_to_channel(&channel_id, &msg);
@@ -199,7 +217,8 @@ pub(super) async fn list_messages(
             .into_iter()
             .map(AttachmentResponse::from)
             .collect();
-        messages.push(MessageResponse::from_message(item, atts));
+        let reactions = enrich_message_with_reactions(&state, item.clone(), &auth.user_id).await?;
+        messages.push(MessageResponse::from_message(item, atts, reactions));
     }
     Ok(Json(MessagePage { messages, has_more }))
 }
@@ -237,7 +256,8 @@ pub(super) async fn get_message(
         .map(AttachmentResponse::from)
         .collect();
 
-    Ok(Json(MessageResponse::from_message(message, atts)))
+    let reactions = enrich_message_with_reactions(&state, message.clone(), &auth.user_id).await?;
+    Ok(Json(MessageResponse::from_message(message, atts, reactions)))
 }
 
 pub(super) async fn update_message(
@@ -285,7 +305,8 @@ pub(super) async fn update_message(
         .into_iter()
         .map(AttachmentResponse::from)
         .collect();
-    let response = MessageResponse::from_message(updated, atts);
+    let reactions = enrich_message_with_reactions(&state, updated.clone(), &auth.user_id).await?;
+    let response = MessageResponse::from_message(updated, atts, reactions);
 
     if let Some(msg) = event_json(Op::MessageUpdate, response.clone()) {
         state.gateway.broadcast_to_channel(&channel_id, &msg);

--- a/server/src/messages/mod.rs
+++ b/server/src/messages/mod.rs
@@ -1,7 +1,7 @@
 mod handlers;
 pub mod models;
 
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post, put};
 use axum::Router;
 
 use crate::AppState;
@@ -17,6 +17,16 @@ pub fn router() -> Router<AppState> {
             get(handlers::get_message)
                 .patch(handlers::update_message)
                 .delete(handlers::delete_message),
+        )
+        .route(
+            "/channels/:channel_id/messages/:message_id/reactions/:emoji",
+            put(crate::reactions::add_reaction)
+                .delete(crate::reactions::remove_own_reaction)
+                .get(crate::reactions::get_reaction_users),
+        )
+        .route(
+            "/channels/:channel_id/messages/:message_id/reactions/:emoji/:user_id",
+            delete(crate::reactions::remove_user_reaction),
         )
 }
 

--- a/server/src/messages/models.rs
+++ b/server/src/messages/models.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::attachments::models::AttachmentResponse;
+use shared::gateway::ReactionCount;
 
 #[derive(Debug, Deserialize)]
 pub struct CreateMessageRequest {
@@ -32,6 +33,8 @@ pub struct MessageResponse {
     pub edited_at: Option<DateTime<Utc>>,
     pub deleted: bool,
     pub attachments: Vec<AttachmentResponse>,
+    #[serde(default)]
+    pub reactions: Vec<ReactionCount>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -41,7 +44,11 @@ pub struct MessagePage {
 }
 
 impl MessageResponse {
-    pub fn from_message(m: crate::storage::models::Message, attachments: Vec<AttachmentResponse>) -> Self {
+    pub fn from_message(
+        m: crate::storage::models::Message,
+        attachments: Vec<AttachmentResponse>,
+        reactions: Vec<ReactionCount>,
+    ) -> Self {
         Self {
             id: m.id,
             channel_id: m.channel_id,
@@ -51,12 +58,13 @@ impl MessageResponse {
             edited_at: m.edited_at,
             deleted: m.deleted,
             attachments,
+            reactions,
         }
     }
 }
 
 impl From<crate::storage::models::Message> for MessageResponse {
     fn from(m: crate::storage::models::Message) -> Self {
-        Self::from_message(m, Vec::new())
+        Self::from_message(m, Vec::new(), Vec::new())
     }
 }

--- a/server/src/reactions/handlers.rs
+++ b/server/src/reactions/handlers.rs
@@ -1,0 +1,259 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Serialize;
+use shared::gateway::Op;
+
+use crate::gateway::events::event_json;
+use crate::permissions::{
+    effective_permissions, has_permission, UserPermissions, ADD_REACTIONS, MANAGE_MESSAGES,
+    READ_MESSAGES,
+};
+use crate::AppState;
+
+#[derive(Debug, Serialize)]
+pub struct ErrorBody {
+    error: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UserResponse {
+    pub id: String,
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReactionListResponse {
+    pub users: Vec<UserResponse>,
+    pub total: i64,
+}
+
+type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorBody>)>;
+
+fn forbidden(msg: impl Into<String>) -> (StatusCode, Json<ErrorBody>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorBody { error: msg.into() }),
+    )
+}
+
+fn not_found(msg: impl Into<String>) -> (StatusCode, Json<ErrorBody>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorBody { error: msg.into() }),
+    )
+}
+
+fn internal(e: crate::storage::StorageError) -> (StatusCode, Json<ErrorBody>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorBody {
+            error: e.to_string(),
+        }),
+    )
+}
+
+fn storage_err(e: crate::storage::StorageError) -> (StatusCode, Json<ErrorBody>) {
+    match e {
+        crate::storage::StorageError::NotFound => not_found("not found"),
+        _ => internal(e),
+    }
+}
+
+async fn check_emoji_reactions_enabled(
+    state: &AppState,
+) -> Result<(), (StatusCode, Json<ErrorBody>)> {
+    if !state.config.features.emoji_reactions {
+        return Err(forbidden("emoji_reactions feature is disabled"));
+    }
+    Ok(())
+}
+
+pub async fn add_reaction(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path((channel_id, message_id, emoji)): Path<(String, String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    check_emoji_reactions_enabled(&state).await?;
+
+    let perms = effective_permissions(state.storage.as_ref(), &auth.user_id, Some(&channel_id))
+        .await
+        .map_err(internal)?;
+
+    if !has_permission(perms, READ_MESSAGES) {
+        return Err(forbidden("missing read_messages permission"));
+    }
+
+    if !has_permission(perms, ADD_REACTIONS) {
+        return Err(forbidden("missing add_reactions permission"));
+    }
+
+    let message = state
+        .storage
+        .get_message(&message_id)
+        .await
+        .map_err(internal)?
+        .ok_or_else(|| not_found("message not found"))?;
+
+    if message.channel_id != channel_id {
+        return Err(not_found("message not found"));
+    }
+
+    let _reaction = state
+        .storage
+        .add_reaction(&message_id, &auth.user_id, &emoji)
+        .await
+        .map_err(storage_err)?;
+
+    let data = shared::gateway::ReactionAddData {
+        channel_id: channel_id.clone(),
+        message_id: message_id.clone(),
+        user_id: auth.user_id.clone(),
+        emoji: emoji.clone(),
+    };
+
+    if let Some(msg) = event_json(Op::ReactionAdd, data) {
+        state.gateway.broadcast_to_channel(&channel_id, &msg);
+    }
+
+    Ok(StatusCode::OK)
+}
+
+pub async fn remove_own_reaction(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path((channel_id, message_id, emoji)): Path<(String, String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    check_emoji_reactions_enabled(&state).await?;
+
+    let perms = effective_permissions(state.storage.as_ref(), &auth.user_id, Some(&channel_id))
+        .await
+        .map_err(internal)?;
+
+    if !has_permission(perms, READ_MESSAGES) {
+        return Err(forbidden("missing read_messages permission"));
+    }
+
+    let message = state
+        .storage
+        .get_message(&message_id)
+        .await
+        .map_err(internal)?
+        .ok_or_else(|| not_found("message not found"))?;
+
+    if message.channel_id != channel_id {
+        return Err(not_found("message not found"));
+    }
+
+    state
+        .storage
+        .remove_reaction(&message_id, &auth.user_id, &emoji)
+        .await
+        .map_err(storage_err)?;
+
+    let data = shared::gateway::ReactionRemoveData {
+        channel_id: channel_id.clone(),
+        message_id: message_id.clone(),
+        user_id: auth.user_id.clone(),
+        emoji: emoji.clone(),
+    };
+
+    if let Some(msg) = event_json(Op::ReactionRemove, data) {
+        state.gateway.broadcast_to_channel(&channel_id, &msg);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn remove_user_reaction(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path((channel_id, message_id, emoji, user_id)): Path<(String, String, String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    check_emoji_reactions_enabled(&state).await?;
+
+    let perms = effective_permissions(state.storage.as_ref(), &auth.user_id, Some(&channel_id))
+        .await
+        .map_err(internal)?;
+
+    if !has_permission(perms, MANAGE_MESSAGES) {
+        return Err(forbidden("missing manage_messages permission"));
+    }
+
+    let message = state
+        .storage
+        .get_message(&message_id)
+        .await
+        .map_err(internal)?
+        .ok_or_else(|| not_found("message not found"))?;
+
+    if message.channel_id != channel_id {
+        return Err(not_found("message not found"));
+    }
+
+    state
+        .storage
+        .remove_user_reaction(&message_id, &user_id, &emoji)
+        .await
+        .map_err(storage_err)?;
+
+    let data = shared::gateway::ReactionRemoveData {
+        channel_id: channel_id.clone(),
+        message_id: message_id.clone(),
+        user_id: user_id.clone(),
+        emoji: emoji.clone(),
+    };
+
+    if let Some(msg) = event_json(Op::ReactionRemove, data) {
+        state.gateway.broadcast_to_channel(&channel_id, &msg);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn get_reaction_users(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path((channel_id, message_id, emoji)): Path<(String, String, String)>,
+) -> ApiResult<ReactionListResponse> {
+    check_emoji_reactions_enabled(&state).await?;
+
+    let perms = effective_permissions(state.storage.as_ref(), &auth.user_id, Some(&channel_id))
+        .await
+        .map_err(internal)?;
+
+    if !has_permission(perms, READ_MESSAGES) {
+        return Err(forbidden("missing read_messages permission"));
+    }
+
+    let message = state
+        .storage
+        .get_message(&message_id)
+        .await
+        .map_err(internal)?
+        .ok_or_else(|| not_found("message not found"))?;
+
+    if message.channel_id != channel_id {
+        return Err(not_found("message not found"));
+    }
+
+    let users = state
+        .storage
+        .list_users_for_reaction(&message_id, &emoji)
+        .await
+        .map_err(storage_err)?;
+
+    let total = users.len() as i64;
+    let responses = users
+        .into_iter()
+        .map(|u| UserResponse {
+            id: u.id,
+            display_name: u.display_name,
+        })
+        .collect();
+
+    Ok(Json(ReactionListResponse {
+        users: responses,
+        total,
+    }))
+}

--- a/server/src/reactions/mod.rs
+++ b/server/src/reactions/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+
+pub use handlers::{add_reaction, get_reaction_users, remove_own_reaction, remove_user_reaction};

--- a/server/src/storage/models.rs
+++ b/server/src/storage/models.rs
@@ -117,3 +117,11 @@ pub struct Attachment {
     pub created_at: DateTime<Utc>,
     pub deleted_at: Option<DateTime<Utc>>,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Reaction {
+    pub message_id: String,
+    pub user_id: String,
+    pub emoji: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/server/src/storage/sqlite/mod.rs
+++ b/server/src/storage/sqlite/mod.rs
@@ -4,6 +4,7 @@ mod invites;
 mod media;
 mod membership;
 mod messages;
+mod reactions;
 mod roles;
 mod sessions;
 mod users;

--- a/server/src/storage/sqlite/reactions.rs
+++ b/server/src/storage/sqlite/reactions.rs
@@ -1,0 +1,238 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+
+use super::SqliteStorage;
+use crate::storage::models::{Reaction, User};
+use crate::storage::traits::ReactionStore;
+use crate::storage::StorageError;
+
+fn row_to_reaction(row: sqlx::sqlite::SqliteRow) -> Result<Reaction, StorageError> {
+    Ok(Reaction {
+        message_id: row.try_get("message_id")?,
+        user_id: row.try_get("user_id")?,
+        emoji: row.try_get("emoji")?,
+        created_at: row.try_get::<DateTime<Utc>, _>("created_at")?,
+    })
+}
+
+#[async_trait]
+impl ReactionStore for SqliteStorage {
+    async fn add_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+        emoji: &str,
+    ) -> Result<Reaction, StorageError> {
+        sqlx::query(
+            "INSERT OR IGNORE INTO reactions (message_id, user_id, emoji) VALUES (?, ?, ?)",
+        )
+        .bind(message_id)
+        .bind(user_id)
+        .bind(emoji)
+        .execute(self.pool())
+        .await?;
+
+        let row = sqlx::query("SELECT * FROM reactions WHERE message_id = ? AND user_id = ? AND emoji = ?")
+            .bind(message_id)
+            .bind(user_id)
+            .bind(emoji)
+            .fetch_one(self.pool())
+            .await?;
+        row_to_reaction(row)
+    }
+
+    async fn remove_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+        emoji: &str,
+    ) -> Result<(), StorageError> {
+        sqlx::query(
+            "DELETE FROM reactions WHERE message_id = ? AND user_id = ? AND emoji = ?",
+        )
+        .bind(message_id)
+        .bind(user_id)
+        .bind(emoji)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+
+    async fn remove_user_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+        emoji: &str,
+    ) -> Result<(), StorageError> {
+        sqlx::query(
+            "DELETE FROM reactions WHERE message_id = ? AND user_id = ? AND emoji = ?",
+        )
+        .bind(message_id)
+        .bind(user_id)
+        .bind(emoji)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+
+    async fn list_reactions_for_message(
+        &self,
+        message_id: &str,
+    ) -> Result<Vec<Reaction>, StorageError> {
+        let rows = sqlx::query("SELECT * FROM reactions WHERE message_id = ? ORDER BY created_at ASC")
+            .bind(message_id)
+            .fetch_all(self.pool())
+            .await?;
+        rows.into_iter().map(row_to_reaction).collect()
+    }
+
+    async fn count_reactions_for_message(
+        &self,
+        message_id: &str,
+        current_user_id: &str,
+    ) -> Result<Vec<(String, i64, bool)>, StorageError> {
+        let rows = sqlx::query(
+            "SELECT emoji, COUNT(*) as count, MAX(CASE WHEN user_id = ? THEN 1 ELSE 0 END) as me
+             FROM reactions
+             WHERE message_id = ?
+             GROUP BY emoji
+             ORDER BY emoji",
+        )
+        .bind(current_user_id)
+        .bind(message_id)
+        .fetch_all(self.pool())
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let emoji: String = row.try_get("emoji").unwrap_or_default();
+                let count: i64 = row.try_get("count").unwrap_or(0);
+                let me: i64 = row.try_get("me").unwrap_or(0);
+                (emoji, count, me != 0)
+            })
+            .collect())
+    }
+
+    async fn list_users_for_reaction(
+        &self,
+        message_id: &str,
+        emoji: &str,
+    ) -> Result<Vec<User>, StorageError> {
+        let rows = sqlx::query(
+            "SELECT u.* FROM users u
+             INNER JOIN reactions r ON u.id = r.user_id
+             WHERE r.message_id = ? AND r.emoji = ?
+             ORDER BY r.created_at ASC",
+        )
+        .bind(message_id)
+        .bind(emoji)
+        .fetch_all(self.pool())
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| User {
+                id: row.try_get("id").unwrap_or_default(),
+                pubkey: row.try_get("pubkey").unwrap_or_default(),
+                display_name: row.try_get("display_name").ok(),
+                avatar_hash: row.try_get("avatar_hash").ok(),
+                created_at: row.try_get("created_at").unwrap_or_else(|_| Utc::now()),
+                updated_at: row.try_get("updated_at").unwrap_or_else(|_| Utc::now()),
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::traits::{ChannelStore, MessageStore, UserStore};
+
+    async fn setup() -> (SqliteStorage, String, String, String) {
+        let s = SqliteStorage::in_memory().await.unwrap();
+        let u1 = s.create_user("pk1", Some("user1")).await.unwrap();
+        let u2 = s.create_user("pk2", Some("user2")).await.unwrap();
+        let c = s.create_channel("general", None, 0).await.unwrap();
+        (s, u1.id, u2.id, c.id)
+    }
+
+    #[tokio::test]
+    async fn add_reaction_idempotent() {
+        let (s, u1, _u2, cid) = setup().await;
+        let msg = s.create_message(&cid, &u1, "hello").await.unwrap();
+
+        let r1 = s.add_reaction(&msg.id, &u1, "👍").await.unwrap();
+        assert_eq!(r1.emoji, "👍");
+        assert_eq!(r1.user_id, u1);
+
+        let r2 = s.add_reaction(&msg.id, &u1, "👍").await.unwrap();
+        assert_eq!(r2.emoji, "👍");
+
+        let reactions = s.list_reactions_for_message(&msg.id).await.unwrap();
+        assert_eq!(reactions.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn remove_reaction() {
+        let (s, u1, _u2, cid) = setup().await;
+        let msg = s.create_message(&cid, &u1, "hello").await.unwrap();
+
+        s.add_reaction(&msg.id, &u1, "👍").await.unwrap();
+        let reactions = s.list_reactions_for_message(&msg.id).await.unwrap();
+        assert_eq!(reactions.len(), 1);
+
+        s.remove_reaction(&msg.id, &u1, "👍").await.unwrap();
+        let reactions = s.list_reactions_for_message(&msg.id).await.unwrap();
+        assert_eq!(reactions.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn count_reactions_with_me_flag() {
+        let (s, u1, u2, cid) = setup().await;
+        let msg = s.create_message(&cid, &u1, "hello").await.unwrap();
+
+        s.add_reaction(&msg.id, &u1, "👍").await.unwrap();
+        s.add_reaction(&msg.id, &u2, "👍").await.unwrap();
+        s.add_reaction(&msg.id, &u1, "❤️").await.unwrap();
+
+        let counts = s
+            .count_reactions_for_message(&msg.id, &u1)
+            .await
+            .unwrap();
+        assert_eq!(counts.len(), 2);
+
+        let thumbs_up = counts.iter().find(|(e, _, _)| e == "👍").unwrap();
+        assert_eq!(thumbs_up.1, 2);
+        assert!(thumbs_up.2); // me=true for u1
+
+        let heart = counts.iter().find(|(e, _, _)| e == "❤️").unwrap();
+        assert_eq!(heart.1, 1);
+        assert!(heart.2); // me=true for u1
+
+        let counts_u2 = s
+            .count_reactions_for_message(&msg.id, &u2)
+            .await
+            .unwrap();
+        let heart_u2 = counts_u2.iter().find(|(e, _, _)| e == "❤️").unwrap();
+        assert!(!heart_u2.2); // me=false for u2
+    }
+
+    #[tokio::test]
+    async fn list_users_for_reaction() {
+        let (s, u1, u2, cid) = setup().await;
+        let msg = s.create_message(&cid, &u1, "hello").await.unwrap();
+
+        s.add_reaction(&msg.id, &u1, "👍").await.unwrap();
+        s.add_reaction(&msg.id, &u2, "👍").await.unwrap();
+
+        let users = s
+            .list_users_for_reaction(&msg.id, "👍")
+            .await
+            .unwrap();
+        assert_eq!(users.len(), 2);
+        assert!(users.iter().any(|u| u.id == u1));
+        assert!(users.iter().any(|u| u.id == u2));
+    }
+}

--- a/server/src/storage/traits.rs
+++ b/server/src/storage/traits.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use super::models::{
     AllowlistEntry, Attachment, Ban, Channel, ChannelPermissionOverride, Invite, Member,
-    MemberRole, Message, Role, Session, User,
+    MemberRole, Message, Reaction, Role, Session, User,
 };
 use super::StorageError;
 
@@ -222,6 +222,42 @@ pub trait AttachmentStore: Send + Sync {
     ) -> Result<Vec<Attachment>, StorageError>;
 }
 
+#[async_trait]
+pub trait ReactionStore: Send + Sync {
+    async fn add_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+        emoji: &str,
+    ) -> Result<Reaction, StorageError>;
+    async fn remove_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+        emoji: &str,
+    ) -> Result<(), StorageError>;
+    async fn remove_user_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+        emoji: &str,
+    ) -> Result<(), StorageError>;
+    async fn list_reactions_for_message(
+        &self,
+        message_id: &str,
+    ) -> Result<Vec<Reaction>, StorageError>;
+    async fn count_reactions_for_message(
+        &self,
+        message_id: &str,
+        current_user_id: &str,
+    ) -> Result<Vec<(String, i64, bool)>, StorageError>;
+    async fn list_users_for_reaction(
+        &self,
+        message_id: &str,
+        emoji: &str,
+    ) -> Result<Vec<User>, StorageError>;
+}
+
 pub struct CreateAttachmentParams<'a> {
     pub channel_id: &'a str,
     pub uploader_id: &'a str,
@@ -243,6 +279,7 @@ pub trait Storage:
     + MemberStore
     + MediaStore
     + AttachmentStore
+    + ReactionStore
 {
 }
 
@@ -256,5 +293,6 @@ impl<T> Storage for T where
         + MemberStore
         + MediaStore
         + AttachmentStore
+        + ReactionStore
 {
 }

--- a/shared/src/gateway.rs
+++ b/shared/src/gateway.rs
@@ -23,6 +23,8 @@ pub enum Op {
     MemberKick,
     MemberBan,
     MemberUpdate,
+    ReactionAdd,
+    ReactionRemove,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -108,6 +110,29 @@ impl<'de> Deserialize<'de> for ClientCommand {
             _ => Ok(ClientCommand::Unknown),
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReactionAddData {
+    pub channel_id: String,
+    pub message_id: String,
+    pub user_id: String,
+    pub emoji: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReactionRemoveData {
+    pub channel_id: String,
+    pub message_id: String,
+    pub user_id: String,
+    pub emoji: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReactionCount {
+    pub emoji: String,
+    pub count: i64,
+    pub me: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #19

## Summary
Implemented the Message Reactions feature allowing users to add Unicode emoji reactions to messages with real-time gateway updates. The feature includes comprehensive permission checks, feature flag gating, and Catppuccin theming.

## Changes

**Server-side:**
- Created SQLite migration (008_reactions.sql) with composite key table and CASCADE delete
- Added Reaction model and ReactionCount struct to shared and server storage
- Implemented ReactionStore trait with 6 methods for persistence
- Created 4 REST endpoints: PUT add, DELETE remove-self, DELETE remove-admin, GET list-users
- Integrated permission checks (ADD_REACTIONS, MANAGE_MESSAGES) and feature flag gating
- Enhanced Message responses to include reactions array with count and "me" flag
- Implemented message enrichment pipeline for all message responses

**Client-side:**
- Created reactions API client module following existing patterns
- Extended serverStore with ReactionCount interface and gateway event handlers
- Created ReactionBar component for displaying and toggling reactions
- Created ReactionPicker component for emoji selection (24 common emojis + custom input)
- Integrated into MessageItem with hover state UI for adding reactions

## Testing
- All 95 server tests pass
- All 68 client tests pass
- cargo clippy -- -D warnings: clean
- pnpm lint: clean

## Technical Details
- Composite PK (message_id, user_id, emoji) ensures one reaction per emoji per user
- "Me" flag computed server-side for efficiency
- Gateway events broadcast to all channel subscribers for real-time sync
- Permission model: ADD_REACTIONS to add, MANAGE_MESSAGES to remove others' reactions
- Cascade delete ensures referential integrity when messages are deleted