### PR TITLE
feat: message reactions (#19)

### DIFF
--- a/client/src/api/reactions.ts
+++ b/client/src/api/reactions.ts
@@ -1,0 +1,74 @@
+import { apiRequest } from "../services/api";
+
+export interface ReactionSummary {
+  emoji: string;
+  count: number;
+  me: boolean;
+}
+
+export interface ReactorEntry {
+  id: string;
+  display_name: string | null;
+}
+
+export interface ListReactorsResponse {
+  users: ReactorEntry[];
+  total: number;
+}
+
+export async function putReaction(
+  address: string,
+  token: string,
+  channelId: string,
+  messageId: string,
+  emoji: string,
+): Promise<void> {
+  const encoded = encodeURIComponent(emoji);
+  await apiRequest<void>(
+    address,
+    `/api/v1/channels/${channelId}/messages/${messageId}/reactions/${encoded}`,
+    { token, method: "PUT" },
+  );
+}
+
+export async function deleteOwnReaction(
+  address: string,
+  token: string,
+  channelId: string,
+  messageId: string,
+): Promise<void> {
+  await apiRequest<void>(
+    address,
+    `/api/v1/channels/${channelId}/messages/${messageId}/reactions`,
+    { token, method: "DELETE" },
+  );
+}
+
+export async function deleteUserReaction(
+  address: string,
+  token: string,
+  channelId: string,
+  messageId: string,
+  userId: string,
+): Promise<void> {
+  await apiRequest<void>(
+    address,
+    `/api/v1/channels/${channelId}/messages/${messageId}/reactions/users/${userId}`,
+    { token, method: "DELETE" },
+  );
+}
+
+export async function listReactors(
+  address: string,
+  token: string,
+  channelId: string,
+  messageId: string,
+  emoji: string,
+): Promise<ListReactorsResponse> {
+  const encoded = encodeURIComponent(emoji);
+  return apiRequest<ListReactorsResponse>(
+    address,
+    `/api/v1/channels/${channelId}/messages/${messageId}/reactions/${encoded}`,
+    { token },
+  );
+}

--- a/client/src/components/emoji/EmojiPicker.test.tsx
+++ b/client/src/components/emoji/EmojiPicker.test.tsx
@@ -1,12 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { EmojiPicker } from "./EmojiPicker";
 import { EMOJI_CATEGORIES } from "../../data/emojis";
 
+const nullRef = createRef<HTMLElement>();
+
 describe("EmojiPicker", () => {
   it("renders category tabs and emoji buttons", () => {
-    render(<EmojiPicker onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<EmojiPicker anchorRef={nullRef} onSelect={vi.fn()} onClose={vi.fn()} />);
     // All 8 category tabs
     const tabs = screen.getAllByRole("tab");
     expect(tabs).toHaveLength(EMOJI_CATEGORIES.length);
@@ -17,7 +20,7 @@ describe("EmojiPicker", () => {
 
   it("clicking an emoji calls onSelect with the correct string", () => {
     const onSelect = vi.fn();
-    render(<EmojiPicker onSelect={onSelect} onClose={vi.fn()} />);
+    render(<EmojiPicker anchorRef={nullRef} onSelect={onSelect} onClose={vi.fn()} />);
     // Click the first emoji (grinning face)
     const firstEmoji = screen.getByTitle("grinning face");
     fireEvent.click(firstEmoji);
@@ -26,20 +29,20 @@ describe("EmojiPicker", () => {
 
   it("pressing Escape calls onClose", () => {
     const onClose = vi.fn();
-    render(<EmojiPicker onSelect={vi.fn()} onClose={onClose} />);
+    render(<EmojiPicker anchorRef={nullRef} onSelect={vi.fn()} onClose={onClose} />);
     fireEvent.keyDown(document, { key: "Escape" });
     expect(onClose).toHaveBeenCalled();
   });
 
   it("outside mousedown calls onClose", () => {
     const onClose = vi.fn();
-    render(<EmojiPicker onSelect={vi.fn()} onClose={onClose} />);
+    render(<EmojiPicker anchorRef={nullRef} onSelect={vi.fn()} onClose={onClose} />);
     fireEvent.mouseDown(document.body);
     expect(onClose).toHaveBeenCalled();
   });
 
   it("category tab filters the visible emoji grid", () => {
-    render(<EmojiPicker onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<EmojiPicker anchorRef={nullRef} onSelect={vi.fn()} onClose={vi.fn()} />);
     // Default is "Smileys & Emotion" — should have grinning face
     expect(screen.getByTitle("grinning face")).toBeInTheDocument();
     expect(screen.queryByTitle("waving hand")).not.toBeInTheDocument();

--- a/client/src/components/emoji/EmojiPicker.tsx
+++ b/client/src/components/emoji/EmojiPicker.tsx
@@ -49,7 +49,7 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
   return (
     <div
       ref={pickerRef}
-      className="absolute bottom-full right-0 mb-2 w-72 rounded-lg border border-ctp-surface1 bg-ctp-surface0 shadow-lg"
+      className="absolute bottom-full right-0 z-50 mb-2 w-72 rounded-lg border border-ctp-surface1 bg-ctp-surface0 shadow-lg"
       role="dialog"
       aria-label="Emoji picker"
     >

--- a/client/src/components/emoji/EmojiPicker.tsx
+++ b/client/src/components/emoji/EmojiPicker.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { EMOJI_CATEGORIES, EMOJIS, type EmojiCategory } from "../../data/emojis";
 
 interface EmojiPickerProps {
+  /** The trigger element used to position the picker above it. */
+  anchorRef: React.RefObject<HTMLElement | null>;
   onSelect: (emoji: string) => void;
   onClose: () => void;
 }
@@ -18,22 +21,32 @@ const CATEGORY_ICONS: Record<EmojiCategory, string> = {
   Symbols: "✅",
 };
 
-export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
+const PICKER_WIDTH = 288; // w-72
+
+export function EmojiPicker({ anchorRef, onSelect, onClose }: EmojiPickerProps) {
   const [activeCategory, setActiveCategory] = useState<EmojiCategory>(EMOJI_CATEGORIES[0]);
   const pickerRef = useRef<HTMLDivElement>(null);
 
   const filtered = EMOJIS.filter((e) => e.category === activeCategory);
 
+  // Compute position from anchor; falls back to 0,0 in test environments where anchor is null.
+  const rect = anchorRef.current?.getBoundingClientRect() ?? null;
+  const top = rect ? rect.top - 8 : 0;
+  const left = rect ? rect.right - PICKER_WIDTH : 0;
+
   // Close on outside click
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (pickerRef.current && !pickerRef.current.contains(event.target as Node)) {
+      const target = event.target as Node;
+      const outsidePicker = !pickerRef.current?.contains(target);
+      const outsideAnchor = !anchorRef.current?.contains(target);
+      if (outsidePicker && outsideAnchor) {
         onClose();
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [onClose]);
+  }, [onClose, anchorRef]);
 
   // Close on Escape
   useEffect(() => {
@@ -46,10 +59,11 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
     return () => document.removeEventListener("keydown", handleEscape);
   }, [onClose]);
 
-  return (
+  return createPortal(
     <div
       ref={pickerRef}
-      className="absolute bottom-full right-0 z-50 mb-2 w-72 rounded-lg border border-ctp-surface1 bg-ctp-surface0 shadow-lg"
+      style={{ position: "fixed", top: `${top}px`, left: `${left}px`, transform: "translateY(-100%)" }}
+      className="z-50 w-72 rounded-lg border border-ctp-surface1 bg-ctp-surface0 shadow-lg"
       role="dialog"
       aria-label="Emoji picker"
     >
@@ -88,6 +102,7 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
           ))}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/client/src/components/layout/MessageInput.tsx
+++ b/client/src/components/layout/MessageInput.tsx
@@ -34,6 +34,7 @@ export function MessageInput({ disabled, onSend }: MessageInputProps) {
   const [dragOver, setDragOver] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const emojiButtonRef = useRef<HTMLButtonElement>(null);
 
   const address = useServerStore((s) => s.address);
   const sessionToken = useServerStore((s) => s.sessionToken);
@@ -227,6 +228,7 @@ export function MessageInput({ disabled, onSend }: MessageInputProps) {
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
           {!disabled && (
             <button
+              ref={emojiButtonRef}
               onClick={() => setEmojiOpen((v) => !v)}
               disabled={disabled || sending}
               aria-label="Emoji picker"
@@ -236,12 +238,11 @@ export function MessageInput({ disabled, onSend }: MessageInputProps) {
             </button>
           )}
           {emojiOpen && (
-            <div className="absolute bottom-full right-0 mb-2">
-              <EmojiPicker
-                onSelect={insertAtCursor}
-                onClose={() => setEmojiOpen(false)}
-              />
-            </div>
+            <EmojiPicker
+              anchorRef={emojiButtonRef}
+              onSelect={insertAtCursor}
+              onClose={() => setEmojiOpen(false)}
+            />
           )}
           <button
             onClick={submit}

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -2,6 +2,7 @@ import type { Message } from "../../stores/serverStore";
 import { useMembersStore } from "../../stores/members";
 import { Avatar } from "../profile/Avatar";
 import { MessageAttachment } from "./MessageAttachment";
+import { ReactionBar } from "./ReactionBar";
 
 interface MessageItemProps {
   message: Message;
@@ -55,6 +56,11 @@ export function MessageItem({ message }: MessageItemProps) {
             )}
           </>
         )}
+        <ReactionBar
+          channelId={message.channel_id}
+          messageId={message.id}
+          reactions={message.reactions ?? []}
+        />
       </div>
     </article>
   );

--- a/client/src/components/messages/ReactionBar.tsx
+++ b/client/src/components/messages/ReactionBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import type { ReactionSummary } from "../../api/reactions";
 import { putReaction } from "../../api/reactions";
@@ -13,6 +13,7 @@ interface ReactionBarProps {
 
 export function ReactionBar({ channelId, messageId, reactions }: ReactionBarProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const address = useServerStore((s) => s.address);
   const token = useServerStore((s) => s.sessionToken);
 
@@ -48,8 +49,9 @@ export function ReactionBar({ channelId, messageId, reactions }: ReactionBarProp
         </button>
       ))}
 
-      <div className="relative">
+      <div>
         <button
+          ref={triggerRef}
           onClick={() => setPickerOpen((v) => !v)}
           aria-label="Add reaction"
           className="flex items-center gap-1 rounded-full border border-ctp-overlay0 px-2 py-0.5 text-sm text-ctp-subtext0 transition hover:border-ctp-blue hover:bg-ctp-surface1 hover:text-ctp-text"
@@ -59,6 +61,7 @@ export function ReactionBar({ channelId, messageId, reactions }: ReactionBarProp
         </button>
         {pickerOpen && (
           <EmojiPicker
+            anchorRef={triggerRef}
             onSelect={(emoji) => void handlePickerSelect(emoji)}
             onClose={() => setPickerOpen(false)}
           />

--- a/client/src/components/messages/ReactionBar.tsx
+++ b/client/src/components/messages/ReactionBar.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+
+import type { ReactionSummary } from "../../api/reactions";
+import { putReaction } from "../../api/reactions";
+import { useServerStore } from "../../stores/serverStore";
+import { EmojiPicker } from "../emoji/EmojiPicker";
+
+interface ReactionBarProps {
+  channelId: string;
+  messageId: string;
+  reactions: ReactionSummary[];
+}
+
+export function ReactionBar({ channelId, messageId, reactions }: ReactionBarProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const address = useServerStore((s) => s.address);
+  const token = useServerStore((s) => s.sessionToken);
+
+  async function handleReactionClick(emoji: string) {
+    if (!token) return;
+    try {
+      await putReaction(address, token, channelId, messageId, emoji);
+    } catch {
+      // Ignore — gateway event will reconcile state
+    }
+  }
+
+  async function handlePickerSelect(emoji: string) {
+    setPickerOpen(false);
+    await handleReactionClick(emoji);
+  }
+
+  return (
+    <div className="relative mt-1.5 flex flex-wrap items-center gap-1">
+      {reactions.map((r) => (
+        <button
+          key={r.emoji}
+          onClick={() => void handleReactionClick(r.emoji)}
+          title={`${r.emoji} · ${r.count}`}
+          className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-sm transition ${
+            r.me
+              ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue hover:bg-ctp-blue/30"
+              : "border-ctp-overlay0 bg-ctp-surface0 text-ctp-text hover:bg-ctp-surface1"
+          }`}
+        >
+          <span>{r.emoji}</span>
+          <span className="text-xs font-medium">{r.count}</span>
+        </button>
+      ))}
+
+      <div className="relative">
+        <button
+          onClick={() => setPickerOpen((v) => !v)}
+          aria-label="Add reaction"
+          className="flex items-center gap-1 rounded-full border border-ctp-overlay0 px-2 py-0.5 text-sm text-ctp-subtext0 transition hover:border-ctp-blue hover:bg-ctp-surface1 hover:text-ctp-text"
+        >
+          <span>😊</span>
+          <span className="text-xs">+</span>
+        </button>
+        {pickerOpen && (
+          <EmojiPicker
+            onSelect={(emoji) => void handlePickerSelect(emoji)}
+            onClose={() => setPickerOpen(false)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import type { CreateChannelRequest, UpdateChannelRequest } from "../api/channels";
 import * as channelsApi from "../api/channels";
 import type { Attachment } from "../api/media";
+import type { ReactionSummary } from "../api/reactions";
 import type { ChannelPermissionOverride, Role } from "../api/roles";
 import { listRoles } from "../api/roles";
 import { ApiError, apiRequest } from "../services/api";
@@ -28,6 +29,7 @@ export interface Message {
   edited_at: string | null;
   deleted: boolean;
   attachments: Attachment[];
+  reactions: ReactionSummary[];
 }
 
 interface ChannelsResponse {
@@ -41,12 +43,20 @@ interface MessagePage {
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected" | "reconnecting";
 
+export interface ReactionEvent {
+  channel_id: string;
+  message_id: string;
+  user_id: string;
+  emoji: string;
+}
+
 export interface GatewayEvent {
   op: string;
   d:
     | Message
     | Channel
     | Role
+    | ReactionEvent
     | { id: string; channel_id?: string }
     | { user_id: string; role_id: string }
     | { user_id: string; pubkey: string; roles: string[]; joined_at: string }
@@ -465,6 +475,49 @@ export const useServerStore = create<ServerStore>((set, get) => ({
         case "MEMBER_UPDATE": {
           useMembersStore.getState().applyGatewayEvent(event);
           return {};
+        }
+        case "REACTION_ADD": {
+          const ev = event.d as ReactionEvent;
+          const existing = state.messages[ev.channel_id] ?? [];
+          return {
+            messages: {
+              ...state.messages,
+              [ev.channel_id]: existing.map((m) => {
+                if (m.id !== ev.message_id) return m;
+                const reactions = m.reactions.filter((r) => r.emoji !== ev.emoji);
+                const prev = m.reactions.find((r) => r.emoji === ev.emoji);
+                reactions.push({
+                  emoji: ev.emoji,
+                  count: (prev?.count ?? 0) + 1,
+                  me: ev.user_id === state.sessionUserId ? true : (prev?.me ?? false),
+                });
+                return { ...m, reactions };
+              }),
+            },
+          };
+        }
+        case "REACTION_REMOVE": {
+          const ev = event.d as ReactionEvent;
+          const existing = state.messages[ev.channel_id] ?? [];
+          return {
+            messages: {
+              ...state.messages,
+              [ev.channel_id]: existing.map((m) => {
+                if (m.id !== ev.message_id) return m;
+                const reactions = m.reactions
+                  .map((r) => {
+                    if (r.emoji !== ev.emoji) return r;
+                    return {
+                      ...r,
+                      count: r.count - 1,
+                      me: ev.user_id === state.sessionUserId ? false : r.me,
+                    };
+                  })
+                  .filter((r) => r.count > 0);
+                return { ...m, reactions };
+              }),
+            },
+          };
         }
         default:
           return {};

--- a/server/migrations/007_reactions.sql
+++ b/server/migrations/007_reactions.sql
@@ -1,0 +1,9 @@
+CREATE TABLE reactions (
+    message_id TEXT NOT NULL REFERENCES messages(id),
+    user_id    TEXT NOT NULL REFERENCES users(id),
+    emoji      TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (message_id, user_id)
+);
+
+CREATE INDEX idx_reactions_message ON reactions(message_id);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -8,6 +8,7 @@ mod membership;
 mod messages;
 mod permissions;
 mod profiles;
+mod reactions;
 mod roles;
 mod server_info;
 mod storage;
@@ -53,6 +54,7 @@ pub fn app(state: AppState) -> Router {
         .nest("/api/v1", server_info::router())
         .nest("/api/v1", profiles::profile_router())
         .nest("/api/v1", attachments::router())
+        .nest("/api/v1", reactions::router())
         .nest("/api/v1/auth", auth::router())
         .nest("/api/v1/gateway", gateway::router())
         .layer(cors_layer())

--- a/server/src/messages/handlers.rs
+++ b/server/src/messages/handlers.rs
@@ -7,7 +7,8 @@ use shared::gateway::Op;
 use crate::attachments::models::AttachmentResponse;
 use crate::gateway::events::event_json;
 use crate::messages::models::{
-    CreateMessageRequest, ListMessagesQuery, MessagePage, MessageResponse, UpdateMessageRequest,
+    CreateMessageRequest, ListMessagesQuery, MessagePage, MessageResponse, ReactionSummary,
+    UpdateMessageRequest,
 };
 use crate::permissions::{
     effective_permissions, has_permission, UserPermissions, MANAGE_MESSAGES, READ_MESSAGES,
@@ -86,6 +87,30 @@ fn validate_message_content(content: &str, max_len: usize) -> Result<(), (Status
     Ok(())
 }
 
+async fn enrich_message(
+    state: &AppState,
+    message: crate::storage::models::Message,
+    viewer_id: &str,
+) -> Result<MessageResponse, (StatusCode, Json<ErrorBody>)> {
+    let atts = state
+        .storage
+        .list_attachments_for_message(&message.id)
+        .await
+        .map_err(internal)?
+        .into_iter()
+        .map(AttachmentResponse::from)
+        .collect();
+    let reactions = state
+        .storage
+        .list_reaction_counts(&message.id, viewer_id)
+        .await
+        .map_err(internal)?
+        .into_iter()
+        .map(ReactionSummary::from)
+        .collect();
+    Ok(MessageResponse::from_message(message, atts, reactions))
+}
+
 async fn ensure_channel_exists(
     state: &AppState,
     channel_id: &str,
@@ -148,7 +173,7 @@ pub(super) async fn create_message(
         Vec::new()
     };
 
-    let response = MessageResponse::from_message(message, attachments);
+    let response = MessageResponse::from_message(message, attachments, Vec::new());
 
     if let Some(msg) = event_json(Op::MessageCreate, response.clone()) {
         state.gateway.broadcast_to_channel(&channel_id, &msg);
@@ -191,15 +216,7 @@ pub(super) async fn list_messages(
 
     let mut messages = Vec::with_capacity(items.len());
     for item in items {
-        let atts = state
-            .storage
-            .list_attachments_for_message(&item.id)
-            .await
-            .map_err(internal)?
-            .into_iter()
-            .map(AttachmentResponse::from)
-            .collect();
-        messages.push(MessageResponse::from_message(item, atts));
+        messages.push(enrich_message(&state, item, &auth.user_id).await?);
     }
     Ok(Json(MessagePage { messages, has_more }))
 }
@@ -228,16 +245,7 @@ pub(super) async fn get_message(
         return Err(not_found("message not found"));
     }
 
-    let atts = state
-        .storage
-        .list_attachments_for_message(&message.id)
-        .await
-        .map_err(internal)?
-        .into_iter()
-        .map(AttachmentResponse::from)
-        .collect();
-
-    Ok(Json(MessageResponse::from_message(message, atts)))
+    Ok(Json(enrich_message(&state, message, &auth.user_id).await?))
 }
 
 pub(super) async fn update_message(
@@ -277,15 +285,7 @@ pub(super) async fn update_message(
         .update_message(&message_id, &req.content)
         .await
         .map_err(storage_err)?;
-    let atts = state
-        .storage
-        .list_attachments_for_message(&updated.id)
-        .await
-        .map_err(internal)?
-        .into_iter()
-        .map(AttachmentResponse::from)
-        .collect();
-    let response = MessageResponse::from_message(updated, atts);
+    let response = enrich_message(&state, updated, &auth.user_id).await?;
 
     if let Some(msg) = event_json(Op::MessageUpdate, response.clone()) {
         state.gateway.broadcast_to_channel(&channel_id, &msg);

--- a/server/src/messages/models.rs
+++ b/server/src/messages/models.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::attachments::models::AttachmentResponse;
+use crate::storage::models::ReactionCount;
 
 #[derive(Debug, Deserialize)]
 pub struct CreateMessageRequest {
@@ -23,6 +24,23 @@ pub struct ListMessagesQuery {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReactionSummary {
+    pub emoji: String,
+    pub count: i64,
+    pub me: bool,
+}
+
+impl From<ReactionCount> for ReactionSummary {
+    fn from(r: ReactionCount) -> Self {
+        Self {
+            emoji: r.emoji,
+            count: r.count,
+            me: r.me,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageResponse {
     pub id: String,
     pub channel_id: String,
@@ -32,6 +50,7 @@ pub struct MessageResponse {
     pub edited_at: Option<DateTime<Utc>>,
     pub deleted: bool,
     pub attachments: Vec<AttachmentResponse>,
+    pub reactions: Vec<ReactionSummary>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -41,7 +60,11 @@ pub struct MessagePage {
 }
 
 impl MessageResponse {
-    pub fn from_message(m: crate::storage::models::Message, attachments: Vec<AttachmentResponse>) -> Self {
+    pub fn from_message(
+        m: crate::storage::models::Message,
+        attachments: Vec<AttachmentResponse>,
+        reactions: Vec<ReactionSummary>,
+    ) -> Self {
         Self {
             id: m.id,
             channel_id: m.channel_id,
@@ -51,12 +74,13 @@ impl MessageResponse {
             edited_at: m.edited_at,
             deleted: m.deleted,
             attachments,
+            reactions,
         }
     }
 }
 
 impl From<crate::storage::models::Message> for MessageResponse {
     fn from(m: crate::storage::models::Message) -> Self {
-        Self::from_message(m, Vec::new())
+        Self::from_message(m, Vec::new(), Vec::new())
     }
 }

--- a/server/src/reactions/handlers.rs
+++ b/server/src/reactions/handlers.rs
@@ -1,0 +1,258 @@
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use shared::gateway::{Op, ReactionEventData};
+
+use crate::gateway::events::event_json;
+use crate::permissions::{
+    effective_permissions, has_permission, UserPermissions, ADD_REACTIONS, MANAGE_MESSAGES,
+    READ_MESSAGES,
+};
+use crate::AppState;
+
+#[derive(Debug, Serialize)]
+pub(super) struct ErrorBody {
+    error: String,
+}
+
+type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorBody>)>;
+
+fn forbidden(msg: impl Into<String>) -> (StatusCode, Json<ErrorBody>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorBody { error: msg.into() }),
+    )
+}
+
+fn not_found(msg: impl Into<String>) -> (StatusCode, Json<ErrorBody>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorBody { error: msg.into() }),
+    )
+}
+
+fn internal(e: crate::storage::StorageError) -> (StatusCode, Json<ErrorBody>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorBody {
+            error: e.to_string(),
+        }),
+    )
+}
+
+async fn resolve_message(
+    state: &AppState,
+    channel_id: &str,
+    message_id: &str,
+) -> Result<crate::storage::models::Message, (StatusCode, Json<ErrorBody>)> {
+    let msg = state
+        .storage
+        .get_message(message_id)
+        .await
+        .map_err(internal)?
+        .ok_or_else(|| not_found("message not found"))?;
+    if msg.channel_id != channel_id {
+        return Err(not_found("message not found"));
+    }
+    Ok(msg)
+}
+
+/// PUT /channels/:channel_id/messages/:message_id/reactions/:emoji
+pub(super) async fn put_reaction(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path((channel_id, message_id, emoji)): Path<(String, String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    if !state.config.features.emoji_reactions {
+        return Err(forbidden("emoji_reactions feature is disabled"));
+    }
+
+    let perms = effective_permissions(state.storage.as_ref(), &auth.user_id, Some(&channel_id))
+        .await
+        .map_err(internal)?;
+    if !has_permission(perms, READ_MESSAGES) {
+        return Err(forbidden("missing read_messages permission"));
+    }
+    if !has_permission(perms, ADD_REACTIONS) {
+        return Err(forbidden("missing add_reactions permission"));
+    }
+
+    let _msg = resolve_message(&state, &channel_id, &message_id).await?;
+
+    let result = state
+        .storage
+        .upsert_reaction(&message_id, &auth.user_id, &emoji)
+        .await
+        .map_err(internal)?;
+
+    let op = if result.is_some() {
+        Op::ReactionAdd
+    } else {
+        Op::ReactionRemove
+    };
+
+    if let Some(payload) = event_json(
+        op,
+        ReactionEventData {
+            channel_id: channel_id.clone(),
+            message_id: message_id.clone(),
+            user_id: auth.user_id.clone(),
+            emoji: emoji.clone(),
+        },
+    ) {
+        state.gateway.broadcast_to_channel(&channel_id, &payload);
+    }
+
+    Ok(StatusCode::OK)
+}
+
+/// DELETE /channels/:channel_id/messages/:message_id/reactions
+pub(super) async fn delete_own_reaction(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path((channel_id, message_id)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    if !state.config.features.emoji_reactions {
+        return Err(forbidden("emoji_reactions feature is disabled"));
+    }
+
+    let _msg = resolve_message(&state, &channel_id, &message_id).await?;
+
+    let existing = state
+        .storage
+        .get_user_reaction(&message_id, &auth.user_id)
+        .await
+        .map_err(internal)?;
+
+    state
+        .storage
+        .remove_reaction(&message_id, &auth.user_id)
+        .await
+        .map_err(internal)?;
+
+    if let Some(r) = existing {
+        let emoji = r.emoji;
+        if let Some(payload) = event_json(
+            Op::ReactionRemove,
+            ReactionEventData {
+                channel_id: channel_id.clone(),
+                message_id: message_id.clone(),
+                user_id: auth.user_id.clone(),
+                emoji,
+            },
+        ) {
+            state.gateway.broadcast_to_channel(&channel_id, &payload);
+        }
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DELETE /channels/:channel_id/messages/:message_id/reactions/:user_id
+pub(super) async fn delete_user_reaction(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path((channel_id, message_id, target_user_id)): Path<(String, String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    if !state.config.features.emoji_reactions {
+        return Err(forbidden("emoji_reactions feature is disabled"));
+    }
+
+    let perms = effective_permissions(state.storage.as_ref(), &auth.user_id, Some(&channel_id))
+        .await
+        .map_err(internal)?;
+    if !has_permission(perms, MANAGE_MESSAGES) {
+        return Err(forbidden("missing manage_messages permission"));
+    }
+
+    let _msg = resolve_message(&state, &channel_id, &message_id).await?;
+
+    let existing = state
+        .storage
+        .get_user_reaction(&message_id, &target_user_id)
+        .await
+        .map_err(internal)?;
+
+    state
+        .storage
+        .remove_reaction(&message_id, &target_user_id)
+        .await
+        .map_err(internal)?;
+
+    if let Some(r) = existing {
+        let emoji = r.emoji;
+        if let Some(payload) = event_json(
+            Op::ReactionRemove,
+            ReactionEventData {
+                channel_id: channel_id.clone(),
+                message_id: message_id.clone(),
+                user_id: target_user_id.clone(),
+                emoji,
+            },
+        ) {
+            state.gateway.broadcast_to_channel(&channel_id, &payload);
+        }
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ListReactorsQuery {
+    pub limit: Option<u32>,
+    pub before: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct ReactorEntry {
+    pub id: String,
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct ListReactorsResponse {
+    pub users: Vec<ReactorEntry>,
+    pub total: usize,
+}
+
+/// GET /channels/:channel_id/messages/:message_id/reactions/:emoji
+pub(super) async fn list_reactors(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path((channel_id, message_id, emoji)): Path<(String, String, String)>,
+    Query(query): Query<ListReactorsQuery>,
+) -> ApiResult<ListReactorsResponse> {
+    if !state.config.features.emoji_reactions {
+        return Err(forbidden("emoji_reactions feature is disabled"));
+    }
+
+    let perms = effective_permissions(state.storage.as_ref(), &auth.user_id, Some(&channel_id))
+        .await
+        .map_err(internal)?;
+    if !has_permission(perms, READ_MESSAGES) {
+        return Err(forbidden("missing read_messages permission"));
+    }
+
+    let _msg = resolve_message(&state, &channel_id, &message_id).await?;
+
+    let limit = query.limit.unwrap_or(25).clamp(1, 100);
+    let reactions = state
+        .storage
+        .list_emoji_reactors(&message_id, &emoji, limit, query.before.as_deref())
+        .await
+        .map_err(internal)?;
+
+    let total = reactions.len();
+    let mut users = Vec::with_capacity(total);
+    for r in &reactions {
+        if let Ok(Some(user)) = state.storage.get_user_by_id(&r.user_id).await {
+            users.push(ReactorEntry {
+                id: user.id,
+                display_name: user.display_name,
+            });
+        }
+    }
+
+    Ok(Json(ListReactorsResponse { users, total }))
+}

--- a/server/src/reactions/handlers.rs
+++ b/server/src/reactions/handlers.rs
@@ -86,22 +86,47 @@ pub(super) async fn put_reaction(
         .await
         .map_err(internal)?;
 
-    let op = if result.is_some() {
-        Op::ReactionAdd
-    } else {
-        Op::ReactionRemove
-    };
-
-    if let Some(payload) = event_json(
-        op,
-        ReactionEventData {
-            channel_id: channel_id.clone(),
-            message_id: message_id.clone(),
-            user_id: auth.user_id.clone(),
-            emoji: emoji.clone(),
-        },
-    ) {
-        state.gateway.broadcast_to_channel(&channel_id, &payload);
+    match result {
+        Some((_reaction, replaced_emoji)) => {
+            // If a different emoji was replaced, broadcast its removal first.
+            if let Some(old_emoji) = replaced_emoji {
+                if let Some(payload) = event_json(
+                    Op::ReactionRemove,
+                    ReactionEventData {
+                        channel_id: channel_id.clone(),
+                        message_id: message_id.clone(),
+                        user_id: auth.user_id.clone(),
+                        emoji: old_emoji,
+                    },
+                ) {
+                    state.gateway.broadcast_to_channel(&channel_id, &payload);
+                }
+            }
+            if let Some(payload) = event_json(
+                Op::ReactionAdd,
+                ReactionEventData {
+                    channel_id: channel_id.clone(),
+                    message_id: message_id.clone(),
+                    user_id: auth.user_id.clone(),
+                    emoji: emoji.clone(),
+                },
+            ) {
+                state.gateway.broadcast_to_channel(&channel_id, &payload);
+            }
+        }
+        None => {
+            if let Some(payload) = event_json(
+                Op::ReactionRemove,
+                ReactionEventData {
+                    channel_id: channel_id.clone(),
+                    message_id: message_id.clone(),
+                    user_id: auth.user_id.clone(),
+                    emoji: emoji.clone(),
+                },
+            ) {
+                state.gateway.broadcast_to_channel(&channel_id, &payload);
+            }
+        }
     }
 
     Ok(StatusCode::OK)

--- a/server/src/reactions/mod.rs
+++ b/server/src/reactions/mod.rs
@@ -1,0 +1,22 @@
+mod handlers;
+
+use axum::routing::{delete, put};
+use axum::Router;
+
+use crate::AppState;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/channels/:channel_id/messages/:message_id/reactions/:emoji",
+            put(handlers::put_reaction).get(handlers::list_reactors),
+        )
+        .route(
+            "/channels/:channel_id/messages/:message_id/reactions",
+            delete(handlers::delete_own_reaction),
+        )
+        .route(
+            "/channels/:channel_id/messages/:message_id/reactions/users/:user_id",
+            delete(handlers::delete_user_reaction),
+        )
+}

--- a/server/src/reactions/mod.rs
+++ b/server/src/reactions/mod.rs
@@ -20,3 +20,269 @@ pub fn router() -> Router<AppState> {
             delete(handlers::delete_user_reaction),
         )
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use crate::config::ServerConfig;
+    use crate::messages::models::{MessagePage, MessageResponse};
+    use crate::storage::{DynStorage, SqliteStorage};
+    use crate::{app, AppState};
+
+    async fn test_state() -> AppState {
+        let storage: DynStorage = Arc::new(SqliteStorage::in_memory().await.unwrap());
+        AppState {
+            config: Arc::new(ServerConfig::default()),
+            storage,
+            challenge_store: crate::auth::challenge_store(),
+            gateway: crate::gateway::gateway_handle(),
+        }
+    }
+
+    async fn test_state_reactions_disabled() -> AppState {
+        let storage: DynStorage = Arc::new(SqliteStorage::in_memory().await.unwrap());
+        let mut cfg = ServerConfig::default();
+        cfg.features.emoji_reactions = false;
+        AppState {
+            config: Arc::new(cfg),
+            storage,
+            challenge_store: crate::auth::challenge_store(),
+            gateway: crate::gateway::gateway_handle(),
+        }
+    }
+
+    async fn authed_token(state: &AppState, seed: u8) -> String {
+        use base64::engine::general_purpose::STANDARD as BASE64;
+        use base64::Engine;
+        use ed25519_dalek::Signer;
+
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[seed; 32]);
+        let pubkey = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
+
+        let body = serde_json::json!({ "pubkey": pubkey });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/auth/challenge")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let cr: shared::auth::ChallengeResponse = serde_json::from_slice(&bytes).unwrap();
+
+        let sig = BASE64.encode(signing_key.sign(cr.challenge.as_bytes()).to_bytes());
+        let vbody = serde_json::json!({ "pubkey": pubkey, "signature": sig });
+        let req2 = Request::builder()
+            .method("POST")
+            .uri("/api/v1/auth/verify")
+            .header("content-type", "application/json")
+            .body(Body::from(vbody.to_string()))
+            .unwrap();
+        let resp2 = app(state.clone()).oneshot(req2).await.unwrap();
+        let bytes2 = resp2.into_body().collect().await.unwrap().to_bytes();
+        let vr: shared::auth::VerifyResponse = serde_json::from_slice(&bytes2).unwrap();
+        vr.token
+    }
+
+    async fn create_channel_and_message(state: &AppState, token: &str) -> (String, String) {
+        let channel = state
+            .storage
+            .create_channel("test", None, 0)
+            .await
+            .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/api/v1/channels/{}/messages", channel.id))
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::from(r#"{"content":"hello"}"#))
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let msg: MessageResponse = serde_json::from_slice(&bytes).unwrap();
+        (channel.id, msg.id)
+    }
+
+    async fn put_reaction(
+        state: &AppState,
+        token: &str,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> StatusCode {
+        let req = Request::builder()
+            .method("PUT")
+            .uri(format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}/reactions/{emoji}"
+            ))
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        app(state.clone()).oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn add_reaction_appears_in_message_fetch() {
+        let state = test_state().await;
+        let token = authed_token(&state, 20).await;
+        let (channel_id, message_id) = create_channel_and_message(&state, &token).await;
+
+        let status = put_reaction(&state, &token, &channel_id, &message_id, "thumbsup").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/api/v1/channels/{channel_id}/messages"))
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let page: MessagePage = serde_json::from_slice(&bytes).unwrap();
+        let msg = &page.messages[0];
+        assert_eq!(msg.reactions.len(), 1);
+        assert_eq!(msg.reactions[0].emoji, "thumbsup");
+        assert_eq!(msg.reactions[0].count, 1);
+        assert!(msg.reactions[0].me);
+    }
+
+    #[tokio::test]
+    async fn toggle_same_emoji_removes_reaction() {
+        let state = test_state().await;
+        let token = authed_token(&state, 21).await;
+        let (channel_id, message_id) = create_channel_and_message(&state, &token).await;
+
+        put_reaction(&state, &token, &channel_id, &message_id, "thumbsup").await;
+        // Toggle off
+        let status = put_reaction(&state, &token, &channel_id, &message_id, "thumbsup").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/api/v1/channels/{channel_id}/messages/{message_id}"))
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let msg: MessageResponse = serde_json::from_slice(&bytes).unwrap();
+        assert!(msg.reactions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn replace_reaction_with_different_emoji() {
+        let state = test_state().await;
+        let token = authed_token(&state, 22).await;
+        let (channel_id, message_id) = create_channel_and_message(&state, &token).await;
+
+        put_reaction(&state, &token, &channel_id, &message_id, "thumbsup").await;
+        put_reaction(&state, &token, &channel_id, &message_id, "heart").await;
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/api/v1/channels/{channel_id}/messages/{message_id}"))
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let msg: MessageResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(msg.reactions.len(), 1);
+        assert_eq!(msg.reactions[0].emoji, "heart");
+    }
+
+    #[tokio::test]
+    async fn delete_own_reaction_removes_it() {
+        let state = test_state().await;
+        let token = authed_token(&state, 23).await;
+        let (channel_id, message_id) = create_channel_and_message(&state, &token).await;
+
+        put_reaction(&state, &token, &channel_id, &message_id, "thumbsup").await;
+
+        let req = Request::builder()
+            .method("DELETE")
+            .uri(format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}/reactions"
+            ))
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/api/v1/channels/{channel_id}/messages/{message_id}"))
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let msg: MessageResponse = serde_json::from_slice(&bytes).unwrap();
+        assert!(msg.reactions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reactions_disabled_returns_403() {
+        let state = test_state_reactions_disabled().await;
+        let token = authed_token(&state, 24).await;
+        let (channel_id, message_id) = create_channel_and_message(&state, &token).await;
+
+        let status = put_reaction(&state, &token, &channel_id, &message_id, "thumbsup").await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn manage_messages_can_remove_other_user_reaction() {
+        let state = test_state().await;
+        let admin_token = authed_token(&state, 25).await;
+        let user_token = authed_token(&state, 26).await;
+        let (channel_id, message_id) = create_channel_and_message(&state, &admin_token).await;
+
+        put_reaction(&state, &user_token, &channel_id, &message_id, "thumbsup").await;
+
+        // Get user id from storage via pubkey
+        let user_id = {
+            let signing_key = ed25519_dalek::SigningKey::from_bytes(&[26u8; 32]);
+            let pubkey = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
+            state
+                .storage
+                .get_user_by_pubkey(&pubkey)
+                .await
+                .unwrap()
+                .unwrap()
+                .id
+        };
+
+        // Admin removes user's reaction
+        let req = Request::builder()
+            .method("DELETE")
+            .uri(format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}/reactions/users/{user_id}"
+            ))
+            .header("authorization", format!("Bearer {admin_token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/api/v1/channels/{channel_id}/messages/{message_id}"))
+            .header("authorization", format!("Bearer {admin_token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app(state.clone()).oneshot(req).await.unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let msg: MessageResponse = serde_json::from_slice(&bytes).unwrap();
+        assert!(msg.reactions.is_empty());
+    }
+}

--- a/server/src/storage/models.rs
+++ b/server/src/storage/models.rs
@@ -2,6 +2,21 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Reaction {
+    pub message_id: String,
+    pub user_id: String,
+    pub emoji: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReactionCount {
+    pub emoji: String,
+    pub count: i64,
+    pub me: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct User {
     pub id: String,
     pub pubkey: String,

--- a/server/src/storage/sqlite/mod.rs
+++ b/server/src/storage/sqlite/mod.rs
@@ -4,6 +4,7 @@ mod invites;
 mod media;
 mod membership;
 mod messages;
+mod reactions;
 mod roles;
 mod sessions;
 mod users;

--- a/server/src/storage/sqlite/reactions.rs
+++ b/server/src/storage/sqlite/reactions.rs
@@ -22,8 +22,7 @@ impl ReactionStore for SqliteStorage {
         message_id: &str,
         user_id: &str,
         emoji: &str,
-    ) -> Result<Option<Reaction>, StorageError> {
-        // Check if user already has this exact emoji — toggle (remove) it.
+    ) -> Result<Option<(Reaction, Option<String>)>, StorageError> {
         let existing: Option<String> =
             sqlx::query_scalar("SELECT emoji FROM reactions WHERE message_id = ? AND user_id = ?")
                 .bind(message_id)
@@ -58,7 +57,7 @@ impl ReactionStore for SqliteStorage {
         .fetch_one(self.pool())
         .await?;
 
-        Ok(Some(row_to_reaction(row)?))
+        Ok(Some((row_to_reaction(row)?, existing)))
     }
 
     async fn get_user_reaction(
@@ -172,11 +171,11 @@ mod tests {
     #[tokio::test]
     async fn add_reaction_creates_record() {
         let (s, u1, _u2, msg) = setup().await;
-        let r = s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
-        assert!(r.is_some());
-        let r = r.unwrap();
+        let result = s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
+        let (r, replaced) = result.unwrap();
         assert_eq!(r.emoji, "👍");
         assert_eq!(r.user_id, u1);
+        assert!(replaced.is_none());
     }
 
     #[tokio::test]
@@ -193,7 +192,9 @@ mod tests {
     async fn different_emoji_replaces_reaction() {
         let (s, u1, _u2, msg) = setup().await;
         s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
-        s.upsert_reaction(&msg, &u1, "❤️").await.unwrap();
+        let result = s.upsert_reaction(&msg, &u1, "❤️").await.unwrap();
+        let (_r, replaced) = result.unwrap();
+        assert_eq!(replaced.as_deref(), Some("👍"));
         let counts = s.list_reaction_counts(&msg, &u1).await.unwrap();
         assert_eq!(counts.len(), 1);
         assert_eq!(counts[0].emoji, "❤️");

--- a/server/src/storage/sqlite/reactions.rs
+++ b/server/src/storage/sqlite/reactions.rs
@@ -61,6 +61,21 @@ impl ReactionStore for SqliteStorage {
         Ok(Some(row_to_reaction(row)?))
     }
 
+    async fn get_user_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+    ) -> Result<Option<Reaction>, StorageError> {
+        let row = sqlx::query(
+            "SELECT message_id, user_id, emoji, created_at FROM reactions WHERE message_id = ? AND user_id = ?",
+        )
+        .bind(message_id)
+        .bind(user_id)
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(row_to_reaction).transpose()
+    }
+
     async fn remove_reaction(&self, message_id: &str, user_id: &str) -> Result<(), StorageError> {
         sqlx::query("DELETE FROM reactions WHERE message_id = ? AND user_id = ?")
             .bind(message_id)

--- a/server/src/storage/sqlite/reactions.rs
+++ b/server/src/storage/sqlite/reactions.rs
@@ -1,0 +1,222 @@
+use async_trait::async_trait;
+use sqlx::Row;
+
+use super::SqliteStorage;
+use crate::storage::models::{Reaction, ReactionCount};
+use crate::storage::traits::ReactionStore;
+use crate::storage::StorageError;
+
+fn row_to_reaction(row: sqlx::sqlite::SqliteRow) -> Result<Reaction, StorageError> {
+    Ok(Reaction {
+        message_id: row.try_get("message_id")?,
+        user_id: row.try_get("user_id")?,
+        emoji: row.try_get("emoji")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+#[async_trait]
+impl ReactionStore for SqliteStorage {
+    async fn upsert_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+        emoji: &str,
+    ) -> Result<Option<Reaction>, StorageError> {
+        // Check if user already has this exact emoji — toggle (remove) it.
+        let existing: Option<String> =
+            sqlx::query_scalar("SELECT emoji FROM reactions WHERE message_id = ? AND user_id = ?")
+                .bind(message_id)
+                .bind(user_id)
+                .fetch_optional(self.pool())
+                .await?;
+
+        if existing.as_deref() == Some(emoji) {
+            sqlx::query("DELETE FROM reactions WHERE message_id = ? AND user_id = ?")
+                .bind(message_id)
+                .bind(user_id)
+                .execute(self.pool())
+                .await?;
+            return Ok(None);
+        }
+
+        sqlx::query(
+            "INSERT INTO reactions (message_id, user_id, emoji) VALUES (?, ?, ?)
+             ON CONFLICT(message_id, user_id) DO UPDATE SET emoji = excluded.emoji, created_at = datetime('now')",
+        )
+        .bind(message_id)
+        .bind(user_id)
+        .bind(emoji)
+        .execute(self.pool())
+        .await?;
+
+        let row = sqlx::query(
+            "SELECT message_id, user_id, emoji, created_at FROM reactions WHERE message_id = ? AND user_id = ?",
+        )
+        .bind(message_id)
+        .bind(user_id)
+        .fetch_one(self.pool())
+        .await?;
+
+        Ok(Some(row_to_reaction(row)?))
+    }
+
+    async fn remove_reaction(&self, message_id: &str, user_id: &str) -> Result<(), StorageError> {
+        sqlx::query("DELETE FROM reactions WHERE message_id = ? AND user_id = ?")
+            .bind(message_id)
+            .bind(user_id)
+            .execute(self.pool())
+            .await?;
+        Ok(())
+    }
+
+    async fn list_reaction_counts(
+        &self,
+        message_id: &str,
+        viewer_id: &str,
+    ) -> Result<Vec<ReactionCount>, StorageError> {
+        let rows = sqlx::query(
+            "SELECT emoji,
+                    COUNT(*) as count,
+                    SUM(CASE WHEN user_id = ? THEN 1 ELSE 0 END) as me_count
+             FROM reactions
+             WHERE message_id = ?
+             GROUP BY emoji
+             ORDER BY MIN(created_at)",
+        )
+        .bind(viewer_id)
+        .bind(message_id)
+        .fetch_all(self.pool())
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                let me_count: i64 = row.try_get("me_count")?;
+                Ok(ReactionCount {
+                    emoji: row.try_get("emoji")?,
+                    count: row.try_get("count")?,
+                    me: me_count > 0,
+                })
+            })
+            .collect()
+    }
+
+    async fn list_emoji_reactors(
+        &self,
+        message_id: &str,
+        emoji: &str,
+        limit: u32,
+        before: Option<&str>,
+    ) -> Result<Vec<Reaction>, StorageError> {
+        let limit = limit.min(100) as i64;
+        let rows = match before {
+            Some(cursor) => {
+                sqlx::query(
+                    "SELECT message_id, user_id, emoji, created_at FROM reactions
+                     WHERE message_id = ? AND emoji = ? AND user_id < ?
+                     ORDER BY user_id DESC LIMIT ?",
+                )
+                .bind(message_id)
+                .bind(emoji)
+                .bind(cursor)
+                .bind(limit)
+                .fetch_all(self.pool())
+                .await?
+            }
+            None => {
+                sqlx::query(
+                    "SELECT message_id, user_id, emoji, created_at FROM reactions
+                     WHERE message_id = ? AND emoji = ?
+                     ORDER BY created_at ASC LIMIT ?",
+                )
+                .bind(message_id)
+                .bind(emoji)
+                .bind(limit)
+                .fetch_all(self.pool())
+                .await?
+            }
+        };
+        rows.into_iter().map(row_to_reaction).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::traits::{ChannelStore, MessageStore, UserStore};
+
+    async fn setup() -> (SqliteStorage, String, String, String) {
+        let s = SqliteStorage::in_memory().await.unwrap();
+        let u1 = s.create_user("pk1", Some("Alice")).await.unwrap();
+        let u2 = s.create_user("pk2", Some("Bob")).await.unwrap();
+        let c = s.create_channel("general", None, 0).await.unwrap();
+        let m = s.create_message(&c.id, &u1.id, "hello").await.unwrap();
+        (s, u1.id, u2.id, m.id)
+    }
+
+    #[tokio::test]
+    async fn add_reaction_creates_record() {
+        let (s, u1, _u2, msg) = setup().await;
+        let r = s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
+        assert!(r.is_some());
+        let r = r.unwrap();
+        assert_eq!(r.emoji, "👍");
+        assert_eq!(r.user_id, u1);
+    }
+
+    #[tokio::test]
+    async fn same_emoji_twice_toggles_off() {
+        let (s, u1, _u2, msg) = setup().await;
+        s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
+        let result = s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
+        assert!(result.is_none());
+        let counts = s.list_reaction_counts(&msg, &u1).await.unwrap();
+        assert!(counts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn different_emoji_replaces_reaction() {
+        let (s, u1, _u2, msg) = setup().await;
+        s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
+        s.upsert_reaction(&msg, &u1, "❤️").await.unwrap();
+        let counts = s.list_reaction_counts(&msg, &u1).await.unwrap();
+        assert_eq!(counts.len(), 1);
+        assert_eq!(counts[0].emoji, "❤️");
+    }
+
+    #[tokio::test]
+    async fn remove_reaction_deletes_record() {
+        let (s, u1, _u2, msg) = setup().await;
+        s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
+        s.remove_reaction(&msg, &u1).await.unwrap();
+        let counts = s.list_reaction_counts(&msg, &u1).await.unwrap();
+        assert!(counts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn aggregate_counts_and_me_flag() {
+        let (s, u1, u2, msg) = setup().await;
+        s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
+        s.upsert_reaction(&msg, &u2, "👍").await.unwrap();
+        s.upsert_reaction(&msg, &u1, "❤️").await.unwrap();
+
+        // u1 toggled 👍 off by adding ❤️ replacing it, but wait — u1 added 👍 then ❤️ replaces it
+        // So u2 has 👍, u1 has ❤️
+        let counts = s.list_reaction_counts(&msg, &u1).await.unwrap();
+        let thumbs = counts.iter().find(|c| c.emoji == "👍").unwrap();
+        assert_eq!(thumbs.count, 1);
+        assert!(!thumbs.me); // u1 does not have 👍
+        let heart = counts.iter().find(|c| c.emoji == "❤️").unwrap();
+        assert_eq!(heart.count, 1);
+        assert!(heart.me); // u1 has ❤️
+    }
+
+    #[tokio::test]
+    async fn list_emoji_reactors_returns_users() {
+        let (s, u1, u2, msg) = setup().await;
+        s.upsert_reaction(&msg, &u1, "👍").await.unwrap();
+        s.upsert_reaction(&msg, &u2, "👍").await.unwrap();
+        let reactors = s.list_emoji_reactors(&msg, "👍", 10, None).await.unwrap();
+        assert_eq!(reactors.len(), 2);
+    }
+}

--- a/server/src/storage/traits.rs
+++ b/server/src/storage/traits.rs
@@ -224,14 +224,16 @@ pub trait AttachmentStore: Send + Sync {
 
 #[async_trait]
 pub trait ReactionStore: Send + Sync {
-    /// Add or replace the current user's reaction. Returns (reaction, replaced_emoji).
-    /// If the user already had the same emoji, removes it (toggle) and returns None.
+    /// Add or replace the current user's reaction.
+    /// Returns `Some((reaction, replaced_emoji))` on add/replace, where `replaced_emoji` is
+    /// `Some(old_emoji)` when a previous reaction was overwritten.
+    /// Returns `None` when the same emoji was toggled off (removed).
     async fn upsert_reaction(
         &self,
         message_id: &str,
         user_id: &str,
         emoji: &str,
-    ) -> Result<Option<Reaction>, StorageError>;
+    ) -> Result<Option<(Reaction, Option<String>)>, StorageError>;
 
     async fn get_user_reaction(
         &self,

--- a/server/src/storage/traits.rs
+++ b/server/src/storage/traits.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use super::models::{
     AllowlistEntry, Attachment, Ban, Channel, ChannelPermissionOverride, Invite, Member,
-    MemberRole, Message, Role, Session, User,
+    MemberRole, Message, Reaction, ReactionCount, Role, Session, User,
 };
 use super::StorageError;
 
@@ -222,6 +222,36 @@ pub trait AttachmentStore: Send + Sync {
     ) -> Result<Vec<Attachment>, StorageError>;
 }
 
+#[async_trait]
+pub trait ReactionStore: Send + Sync {
+    /// Add or replace the current user's reaction. Returns (reaction, replaced_emoji).
+    /// If the user already had the same emoji, removes it (toggle) and returns None.
+    async fn upsert_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+        emoji: &str,
+    ) -> Result<Option<Reaction>, StorageError>;
+
+    async fn remove_reaction(&self, message_id: &str, user_id: &str) -> Result<(), StorageError>;
+
+    /// Aggregate counts per emoji, with a `me` flag for `viewer_id`.
+    async fn list_reaction_counts(
+        &self,
+        message_id: &str,
+        viewer_id: &str,
+    ) -> Result<Vec<ReactionCount>, StorageError>;
+
+    /// List users who reacted with a specific emoji (paginated).
+    async fn list_emoji_reactors(
+        &self,
+        message_id: &str,
+        emoji: &str,
+        limit: u32,
+        before: Option<&str>,
+    ) -> Result<Vec<Reaction>, StorageError>;
+}
+
 pub struct CreateAttachmentParams<'a> {
     pub channel_id: &'a str,
     pub uploader_id: &'a str,
@@ -243,6 +273,7 @@ pub trait Storage:
     + MemberStore
     + MediaStore
     + AttachmentStore
+    + ReactionStore
 {
 }
 
@@ -256,5 +287,6 @@ impl<T> Storage for T where
         + MemberStore
         + MediaStore
         + AttachmentStore
+        + ReactionStore
 {
 }

--- a/server/src/storage/traits.rs
+++ b/server/src/storage/traits.rs
@@ -233,6 +233,12 @@ pub trait ReactionStore: Send + Sync {
         emoji: &str,
     ) -> Result<Option<Reaction>, StorageError>;
 
+    async fn get_user_reaction(
+        &self,
+        message_id: &str,
+        user_id: &str,
+    ) -> Result<Option<Reaction>, StorageError>;
+
     async fn remove_reaction(&self, message_id: &str, user_id: &str) -> Result<(), StorageError>;
 
     /// Aggregate counts per emoji, with a `me` flag for `viewer_id`.

--- a/shared/src/gateway.rs
+++ b/shared/src/gateway.rs
@@ -23,6 +23,8 @@ pub enum Op {
     MemberKick,
     MemberBan,
     MemberUpdate,
+    ReactionAdd,
+    ReactionRemove,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -59,6 +61,14 @@ pub struct EmptyData {}
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SubscriptionData {
     pub channel_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReactionEventData {
+    pub channel_id: String,
+    pub message_id: String,
+    pub user_id: String,
+    pub emoji: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]


### PR DESCRIPTION
Closes #19

## Summary
- One reaction per user per message (adding same emoji toggles off; different emoji replaces)
- Feature-flagged behind `emoji_reactions` (enabled by default)
- `ADD_REACTIONS` permission gates adding; removing own is always allowed; `MANAGE_MESSAGES` can remove any user's reaction
- Real-time via `REACTION_ADD` / `REACTION_REMOVE` gateway events

## Changes
- `server/migrations/007_reactions.sql` — reactions table with composite PK `(message_id, user_id)`
- `shared/src/gateway.rs` — `ReactionAdd`, `ReactionRemove` op variants + `ReactionEventData`
- `server/src/storage/` — `ReactionStore` trait + SQLite impl (upsert/toggle, remove, count, list)
- `server/src/reactions/` — REST handlers: PUT toggle, DELETE self, DELETE user (admin), GET reactors
- `server/src/messages/` — `MessageResponse.reactions` enriched on every message fetch
- `client/src/api/reactions.ts` — API client functions
- `client/src/stores/serverStore.ts` — REACTION_ADD/REMOVE gateway event handlers
- `client/src/components/messages/ReactionBar.tsx` — reaction pills + emoji picker
- `client/src/components/messages/MessageItem.tsx` — integrates ReactionBar

## Testing
- All existing tests pass (126 Rust, 68 JS)
- 6 storage unit tests (add, toggle, replace, remove, counts, list reactors)
- 6 integration tests (add reaction, toggle off, replace, delete own, disabled 403, admin remove)
- cargo clippy -- -D warnings: clean
- pnpm lint: clean