### PR TITLE
feat: in-app About / Welcome modal (#80)

### DIFF
--- a/client/src/components/about/About.test.tsx
+++ b/client/src/components/about/About.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { About } from "./About";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("../ui/Modal", () => ({
+  Modal: ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => (
+    <div data-testid="modal">
+      <button data-testid="backdrop-close" onClick={onClose}>backdrop</button>
+      {children}
+    </div>
+  ),
+}));
+
+describe("About", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without crashing", () => {
+    render(<About onClose={onClose} />);
+    expect(screen.getByText("About decentcom")).toBeInTheDocument();
+  });
+
+  it("clicking Close button dismisses the modal", () => {
+    render(<About onClose={onClose} />);
+    fireEvent.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking the ✕ button dismisses the modal", () => {
+    render(<About onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows key strengths", () => {
+    render(<About onClose={onClose} />);
+    expect(screen.getByText("Identity ownership", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("No passwords", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Self-hostable", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Cryptographically secure", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Open source", { exact: false })).toBeInTheDocument();
+  });
+
+  it("renders external links", () => {
+    render(<About onClose={onClose} />);
+    expect(screen.getByText("Documentation")).toBeInTheDocument();
+    expect(screen.getByText("Source Repository")).toBeInTheDocument();
+    expect(screen.getByText("Download Page")).toBeInTheDocument();
+  });
+
+  it("external links call openUrl instead of navigating", async () => {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    render(<About onClose={onClose} />);
+    fireEvent.click(screen.getByText("Documentation"));
+    expect(openUrl).toHaveBeenCalledWith("https://github.com/icub3d/decentcom/wiki");
+  });
+});

--- a/client/src/components/about/About.tsx
+++ b/client/src/components/about/About.tsx
@@ -1,0 +1,122 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Modal } from "../ui/Modal";
+
+interface AboutProps {
+  onClose: () => void;
+}
+
+const LINKS = {
+  docs: "https://github.com/icub3d/decentcom/wiki",
+  source: "https://github.com/icub3d/decentcom",
+  download: "https://decentcom.app",
+};
+
+function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    void openUrl(href);
+  };
+  return (
+    <a
+      href={href}
+      onClick={handleClick}
+      className="text-ctp-blue hover:text-ctp-sapphire underline transition-colors cursor-pointer"
+    >
+      {children}
+    </a>
+  );
+}
+
+export function About({ onClose }: AboutProps) {
+  return (
+    <Modal onClose={onClose}>
+      <div className="w-full max-w-lg p-8 space-y-6 text-ctp-text">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold text-ctp-text">About decentcom</h2>
+          <button
+            onClick={onClose}
+            className="text-ctp-subtext1 hover:text-ctp-text transition-colors text-lg leading-none"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <p className="text-ctp-subtext1 leading-relaxed">
+          decentcom is open-source community communication software you can self-host.
+          Your identity is a cryptographic key pair — no password, no email, no central account.
+        </p>
+
+        <div>
+          <h3 className="text-sm font-semibold text-ctp-subtext0 uppercase tracking-wider mb-3">
+            Key Strengths
+          </h3>
+          <ul className="space-y-2 text-sm text-ctp-text">
+            <li className="flex gap-2">
+              <span className="text-ctp-green mt-0.5">✓</span>
+              <span><strong className="text-ctp-green">Identity ownership</strong> — Your account is a key pair you generate. No email, no phone number, no password required.</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-ctp-green mt-0.5">✓</span>
+              <span><strong className="text-ctp-green">No passwords</strong> — Authentication is cryptographic. There is nothing for a server to steal and nothing for a breach to expose.</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-ctp-green mt-0.5">✓</span>
+              <span><strong className="text-ctp-green">Self-hostable</strong> — Any community can run its own server. No subscription, no third-party Terms of Service, no deplatforming risk.</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-ctp-green mt-0.5">✓</span>
+              <span><strong className="text-ctp-green">Cryptographically secure</strong> — Every authentication action is signed. Servers verify identity without storing secrets.</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-ctp-green mt-0.5">✓</span>
+              <span><strong className="text-ctp-green">Open source</strong> — MIT-licensed. Inspect it, fork it, self-host it. The core will always be free.</span>
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-semibold text-ctp-subtext0 uppercase tracking-wider mb-3">
+            Why decentcom?
+          </h3>
+          <div className="text-sm text-ctp-subtext1 space-y-2 leading-relaxed">
+            <p>
+              Most platforms store a password or credential on their servers — which means
+              every breach puts your account at risk. With decentcom, there is nothing to steal.
+            </p>
+            <p>
+              With most services, your account exists at the platform's discretion.
+              Centralized services accumulate metadata about who you talk to and when.
+              On centralized platforms, servers — and your account — can be removed without recourse.
+            </p>
+            <p>
+              decentcom puts control where it belongs: with you and your community.
+              Self-hosting requires effort and being early-stage means fewer integrations,
+              but the tradeoff is a platform that works for you, not for the platform.
+            </p>
+          </div>
+        </div>
+
+        <div className="pt-2 border-t border-ctp-overlay0">
+          <h3 className="text-sm font-semibold text-ctp-subtext0 uppercase tracking-wider mb-3">
+            Links
+          </h3>
+          <div className="flex flex-wrap gap-4 text-sm">
+            <ExternalLink href={LINKS.docs}>Documentation</ExternalLink>
+            <ExternalLink href={LINKS.source}>Source Repository</ExternalLink>
+            <ExternalLink href={LINKS.download}>Download Page</ExternalLink>
+          </div>
+        </div>
+
+        <div className="pt-2 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-6 py-2 bg-ctp-surface0 hover:bg-ctp-surface1 text-ctp-text rounded-lg font-semibold transition-colors cursor-pointer"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/components/layout/TitleBar.tsx
+++ b/client/src/components/layout/TitleBar.tsx
@@ -47,10 +47,10 @@ export function TitleBar() {
         <button
           onClick={() => setShowAbout(true)}
           data-tauri-no-drag
-          className="px-3 h-full flex items-center justify-center hover:bg-ctp-surface0 transition-colors text-ctp-subtext1 hover:text-ctp-text text-xs"
+          className="w-8 h-full flex items-center justify-center hover:bg-ctp-surface0 transition-colors text-ctp-subtext1 hover:text-ctp-text text-sm"
           title="About decentcom"
         >
-          About
+          ⓘ
         </button>
         <button
           onClick={handleMinimize}

--- a/client/src/components/layout/TitleBar.tsx
+++ b/client/src/components/layout/TitleBar.tsx
@@ -1,10 +1,12 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useState } from "react";
+import { About } from "../about/About";
 
 const appWindow = getCurrentWindow();
 
 export function TitleBar() {
   const [isMaximized, setIsMaximized] = useState(false);
+  const [showAbout, setShowAbout] = useState(false);
 
   useEffect(() => {
     const updateMaximized = async () => {
@@ -31,6 +33,8 @@ export function TitleBar() {
   const handleClose = () => appWindow.close();
 
   return (
+    <>
+      {showAbout && <About onClose={() => setShowAbout(false)} />}
     <div
       data-tauri-drag-region
       className="h-8 bg-ctp-crust flex items-center justify-between select-none border-b border-ctp-overlay0"
@@ -40,6 +44,14 @@ export function TitleBar() {
       </div>
 
       <div className="flex items-center h-full">
+        <button
+          onClick={() => setShowAbout(true)}
+          data-tauri-no-drag
+          className="px-3 h-full flex items-center justify-center hover:bg-ctp-surface0 transition-colors text-ctp-subtext1 hover:text-ctp-text text-xs"
+          title="About decentcom"
+        >
+          About
+        </button>
         <button
           onClick={handleMinimize}
           data-tauri-no-drag
@@ -99,5 +111,6 @@ export function TitleBar() {
         </button>
       </div>
     </div>
+    </>
   );
 }

--- a/client/src/pages/Setup.tsx
+++ b/client/src/pages/Setup.tsx
@@ -4,6 +4,7 @@ import { IdentityInfo, PublicKeyInfo } from "../hooks/useIdentity";
 import { KeySafety } from "./KeySafety";
 import { keyImport, keyBackupReadPubkey } from "../services/identity";
 import { useAppStore, type AppBackupState } from "../stores/appStore";
+import { About } from "../components/about/About";
 
 function shortPubkey(pubkey: string): string {
   if (pubkey.length <= 12) return pubkey;
@@ -19,6 +20,7 @@ interface SetupProps {
 
 export function Setup({ onGenerate, onImport, onComplete, onCancel }: SetupProps) {
   const [view, setView] = useState<"choice" | "safety" | "import" | "backup" | "settings-restored">("choice");
+  const [showAbout, setShowAbout] = useState(false);
   const [generatedIdentity, setGeneratedIdentity] = useState<IdentityInfo | null>(null);
   const [importText, setImportText] = useState("");
   const [loading, setLoading] = useState(false);
@@ -246,47 +248,58 @@ export function Setup({ onGenerate, onImport, onComplete, onCancel }: SetupProps
   }
 
   return (
-    <div className="max-w-md mx-auto p-8 space-y-8 bg-ctp-mantle rounded-xl shadow-xl border border-ctp-overlay0 text-ctp-text">
-      <div className="text-center space-y-2">
-        <h1 className="text-3xl font-bold text-ctp-text">
-          {onCancel ? "Add Account" : "Welcome"}
-        </h1>
-        <p className="text-ctp-subtext0">
-          {onCancel
-            ? "Create or import another identity."
-            : "Set up your decentcom identity to get started."}
-        </p>
-      </div>
-      <div className="space-y-4">
-        <button
-          onClick={handleGenerate}
-          disabled={loading}
-          className="w-full py-4 bg-ctp-blue hover:bg-ctp-sapphire disabled:bg-ctp-overlay0 text-ctp-crust rounded-xl font-bold text-lg transition-all shadow-lg hover:scale-[1.02] active:scale-95 cursor-pointer"
-        >
-          {loading ? "Generating..." : "Create New Identity"}
-        </button>
-        <button
-          onClick={() => setView("import")}
-          className="w-full py-4 bg-ctp-surface0 hover:bg-ctp-surface1 text-ctp-text rounded-xl font-bold text-lg transition-all border border-ctp-overlay0 hover:scale-[1.02] active:scale-95 cursor-pointer"
-        >
-          Import Seed Phrase
-        </button>
-        <button
-          onClick={() => setView("backup")}
-          className="w-full py-4 bg-ctp-surface0 hover:bg-ctp-surface1 text-ctp-text rounded-xl font-bold text-lg transition-all border border-ctp-overlay0 hover:scale-[1.02] active:scale-95 cursor-pointer"
-        >
-          Restore from Backup File
-        </button>
-        {onCancel && (
+    <>
+      {showAbout && <About onClose={() => setShowAbout(false)} />}
+      <div className="max-w-md mx-auto p-8 space-y-8 bg-ctp-mantle rounded-xl shadow-xl border border-ctp-overlay0 text-ctp-text">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-bold text-ctp-text">
+            {onCancel ? "Add Account" : "Welcome"}
+          </h1>
+          <p className="text-ctp-subtext0">
+            {onCancel
+              ? "Create or import another identity."
+              : "Set up your decentcom identity to get started."}
+          </p>
+          {!onCancel && (
+            <button
+              onClick={() => setShowAbout(true)}
+              className="text-xs text-ctp-subtext1 hover:text-ctp-blue transition-colors underline cursor-pointer"
+            >
+              Learn more about decentcom
+            </button>
+          )}
+        </div>
+        <div className="space-y-4">
           <button
-            onClick={onCancel}
-            className="w-full py-3 text-ctp-subtext1 hover:text-ctp-text transition-colors text-sm"
+            onClick={handleGenerate}
+            disabled={loading}
+            className="w-full py-4 bg-ctp-blue hover:bg-ctp-sapphire disabled:bg-ctp-overlay0 text-ctp-crust rounded-xl font-bold text-lg transition-all shadow-lg hover:scale-[1.02] active:scale-95 cursor-pointer"
           >
-            Cancel
+            {loading ? "Generating..." : "Create New Identity"}
           </button>
-        )}
+          <button
+            onClick={() => setView("import")}
+            className="w-full py-4 bg-ctp-surface0 hover:bg-ctp-surface1 text-ctp-text rounded-xl font-bold text-lg transition-all border border-ctp-overlay0 hover:scale-[1.02] active:scale-95 cursor-pointer"
+          >
+            Import Seed Phrase
+          </button>
+          <button
+            onClick={() => setView("backup")}
+            className="w-full py-4 bg-ctp-surface0 hover:bg-ctp-surface1 text-ctp-text rounded-xl font-bold text-lg transition-all border border-ctp-overlay0 hover:scale-[1.02] active:scale-95 cursor-pointer"
+          >
+            Restore from Backup File
+          </button>
+          {onCancel && (
+            <button
+              onClick={onCancel}
+              className="w-full py-3 text-ctp-subtext1 hover:text-ctp-text transition-colors text-sm"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+        {error && <p className="text-ctp-red text-center text-sm">{error}</p>}
       </div>
-      {error && <p className="text-ctp-red text-center text-sm">{error}</p>}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #80

## Summary
- New `About.tsx` modal component with brand copy from `docs/brand.md`
- Content includes intro paragraph, key strengths bullets, "Why decentcom?" comparison section, and links
- External links open in the system browser via `tauri-plugin-opener`
- Two entry points: "Learn more about decentcom" link on Setup screen; "About" button in TitleBar

## Changes
- `client/src/components/about/About.tsx` — new modal with full brand copy and external link handling
- `client/src/components/about/About.test.tsx` — unit tests (renders, close button, external links)
- `client/src/components/layout/TitleBar.tsx` — added "About" menu button (left side of window controls)
- `client/src/components/layout/TitleBar.test.tsx` — integration tests for About modal open/close
- `client/src/pages/Setup.tsx` — added "Learn more about decentcom" link (hidden in Add Account flow)
- `client/src/pages/Setup.test.tsx` — integration tests for Learn more link open/close

## Testing
- All 93 tests pass
- cargo clippy -- -D warnings: N/A (frontend-only change)
- pnpm lint: clean (0 warnings)
- Unit: About.tsx renders without crashing ✓
- Unit: clicking Close dismisses the modal ✓
- Integration: "Learn more" link in Setup.tsx opens the modal ✓
- Integration: TitleBar "About" menu item opens the modal ✓
- Manual: external links use openUrl (tauri-plugin-opener) — not an in-app webview

🤖 Generated with [Claude Code](https://claude.com/claude-code)