### PR TITLE
feat: bot account type (#75)

### DIFF
--- a/client/src/api/members.ts
+++ b/client/src/api/members.ts
@@ -12,8 +12,21 @@ export interface Member {
   pubkey: string;
   display_name: string | null;
   avatar_hash: string | null;
+  is_bot: boolean;
   joined_at: string;
   roles: MemberRole[];
+}
+
+export interface BotApproval {
+  pubkey: string;
+  approved_by: string | null;
+  approved_at: string | null;
+  revoked_at: string | null;
+  note: string | null;
+}
+
+interface ListPendingBotsResponse {
+  bots: BotApproval[];
 }
 
 export interface Ban {
@@ -142,5 +155,39 @@ export async function removeRole(
     baseUrl,
     `/api/v1/members/${encodeURIComponent(pubkey)}/roles/${encodeURIComponent(roleId)}`,
     { method: "DELETE", token },
+  );
+}
+
+export async function listPendingBots(baseUrl: string, token: string): Promise<BotApproval[]> {
+  const response = await apiRequest<ListPendingBotsResponse>(
+    baseUrl,
+    "/api/v1/admin/bots/pending",
+    { token },
+  );
+  return response.bots;
+}
+
+export async function approveBot(
+  baseUrl: string,
+  token: string,
+  pubkey: string,
+  note?: string,
+): Promise<BotApproval> {
+  return apiRequest<BotApproval>(
+    baseUrl,
+    `/api/v1/admin/bots/${encodeURIComponent(pubkey)}/approve`,
+    { method: "POST", token, body: JSON.stringify({ note }) },
+  );
+}
+
+export async function revokeBot(
+  baseUrl: string,
+  token: string,
+  pubkey: string,
+): Promise<BotApproval> {
+  return apiRequest<BotApproval>(
+    baseUrl,
+    `/api/v1/admin/bots/${encodeURIComponent(pubkey)}/revoke`,
+    { method: "POST", token },
   );
 }

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -3,6 +3,7 @@ import { apiRequest } from "../services/api";
 export interface ServerInfo {
   name: string;
   description: string | null;
+  membership_mode: string;
 }
 
 export async function getServerInfo(baseUrl: string): Promise<ServerInfo> {

--- a/client/src/components/layout/ServerSidebar.tsx
+++ b/client/src/components/layout/ServerSidebar.tsx
@@ -52,6 +52,7 @@ function initials(name: string | undefined, address: string): string {
 export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwitchAccount }: ServerSidebarProps) {
   const { theme, setTheme, setCurrentServer, removeServer } = useAppStore();
   const address = useServerStore((state) => state.address);
+  const membershipMode = useServerStore((state) => state.membershipMode);
 
   const token = useServerStore((state) => state.sessionToken);
   const roles = useServerStore((state) => state.roles);
@@ -214,7 +215,7 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwit
       {openPanel === "server-settings" && showServerSettings && (
         <div className="absolute bottom-3 left-20 z-10 w-104 pl-2">
           <div className="grid gap-3">
-            <MembershipSettings mode="server-config" />
+            <MembershipSettings mode={membershipMode} />
             {canManageInvites && (
               <>
                 <CreateInviteDialog

--- a/client/src/components/layout/ServerSidebar.tsx
+++ b/client/src/components/layout/ServerSidebar.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { CreateInviteDialog } from "../invites/CreateInviteDialog";
 import { AllowlistEditor } from "../settings/AllowlistEditor";
 import { BanList } from "../settings/BanList";
+import { BotApprovalPanel } from "../settings/BotApprovalPanel";
 import { MembershipSettings } from "../settings/MembershipSettings";
 import { InviteList } from "../invites/InviteList";
 import { ProfileEditor } from "../profile/ProfileEditor";
@@ -69,11 +70,15 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwit
 
   const bans = useMembersStore((state) => state.bans);
   const allowlist = useMembersStore((state) => state.allowlist);
+  const pendingBots = useMembersStore((state) => state.pendingBots);
   const fetchBans = useMembersStore((state) => state.fetchBans);
   const fetchAllowlist = useMembersStore((state) => state.fetchAllowlist);
+  const fetchPendingBots = useMembersStore((state) => state.fetchPendingBots);
   const unbanMember = useMembersStore((state) => state.unban);
   const addAllowlist = useMembersStore((state) => state.addAllowlistEntry);
   const removeAllowlist = useMembersStore((state) => state.removeAllowlistEntry);
+  const approveBotEntry = useMembersStore((state) => state.approveBotEntry);
+  const revokeBotEntry = useMembersStore((state) => state.revokeBotEntry);
 
   const [openPanel, setOpenPanel] = useState<OpenPanel>(null);
 
@@ -111,6 +116,7 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwit
     }
     if (canManageServer) {
       await fetchAllowlist(address, token);
+      await fetchPendingBots(address, token);
     }
   }
 
@@ -247,21 +253,39 @@ export function ServerSidebar({ servers, currentServerId, onSelectServer, onSwit
               />
             )}
             {canManageServer && (
-              <AllowlistEditor
-                entries={allowlist}
-                onAdd={async (pubkey) => {
-                  if (!address || !token) {
-                    throw new Error("Not connected");
-                  }
-                  await addAllowlist(address, token, pubkey);
-                }}
-                onRemove={async (pubkey) => {
-                  if (!address || !token) {
-                    throw new Error("Not connected");
-                  }
-                  await removeAllowlist(address, token, pubkey);
-                }}
-              />
+              <>
+                <AllowlistEditor
+                  entries={allowlist}
+                  onAdd={async (pubkey) => {
+                    if (!address || !token) {
+                      throw new Error("Not connected");
+                    }
+                    await addAllowlist(address, token, pubkey);
+                  }}
+                  onRemove={async (pubkey) => {
+                    if (!address || !token) {
+                      throw new Error("Not connected");
+                    }
+                    await removeAllowlist(address, token, pubkey);
+                  }}
+                />
+                <BotApprovalPanel
+                  pendingBots={pendingBots}
+                  onApprove={async (pubkey) => {
+                    if (!address || !token) {
+                      throw new Error("Not connected");
+                    }
+                    await approveBotEntry(address, token, pubkey);
+                  }}
+                  onRevoke={async (pubkey) => {
+                    if (!address || !token) {
+                      throw new Error("Not connected");
+                    }
+                    await revokeBotEntry(address, token, pubkey);
+                    await fetchPendingBots(address, token);
+                  }}
+                />
+              </>
             )}
           </div>
         </div>

--- a/client/src/components/members/MemberList.tsx
+++ b/client/src/components/members/MemberList.tsx
@@ -51,8 +51,15 @@ export function MemberList({
               <div className="flex items-center gap-2 min-w-0">
                 <Avatar pubkey={member.pubkey} avatarHash={member.avatar_hash} size={28} />
                 <div className="min-w-0">
-                  <div className="text-sm font-semibold text-ctp-text truncate">
-                    {member.display_name ?? truncatePubkey(member.pubkey)}
+                  <div className="flex items-center gap-1">
+                    <span className="text-sm font-semibold text-ctp-text truncate">
+                      {member.display_name ?? truncatePubkey(member.pubkey)}
+                    </span>
+                    {member.is_bot && (
+                      <span className="shrink-0 rounded bg-ctp-blue/20 px-1 py-0.5 text-[10px] font-bold text-ctp-blue">
+                        BOT
+                      </span>
+                    )}
                   </div>
                   {member.display_name && (
                     <div className="text-xs text-ctp-subtext0 truncate">{truncatePubkey(member.pubkey)}</div>

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -55,6 +55,9 @@ export function MessageItem({ message, isReply }: MessageItemProps) {
           <div className="mb-1 flex items-center justify-between">
             <div className="flex items-center gap-2 text-xs text-ctp-subtext0">
               <span className="font-semibold text-ctp-subtext1">{displayName}</span>
+              {member?.is_bot && (
+                <span className="rounded bg-ctp-blue/20 px-1 py-0.5 text-[10px] font-bold text-ctp-blue">BOT</span>
+              )}
               <time>{formatTime(message.created_at)}</time>
               {message.edited_at && !message.deleted && <span className="text-ctp-yellow">(edited)</span>}
             </div>

--- a/client/src/components/settings/BotApprovalPanel.tsx
+++ b/client/src/components/settings/BotApprovalPanel.tsx
@@ -1,0 +1,57 @@
+import type { BotApproval } from "../../api/members";
+
+interface BotApprovalPanelProps {
+  pendingBots: BotApproval[];
+  onApprove: (pubkey: string) => Promise<void>;
+  onRevoke: (pubkey: string) => Promise<void>;
+}
+
+function truncatePubkey(pubkey: string): string {
+  if (pubkey.length <= 14) return pubkey;
+  return `${pubkey.slice(0, 8)}...${pubkey.slice(-6)}`;
+}
+
+export function BotApprovalPanel({ pendingBots, onApprove, onRevoke }: BotApprovalPanelProps) {
+  return (
+    <section className="rounded-xl border border-ctp-overlay0 bg-ctp-mantle/90 p-3">
+      <h3 className="mb-3 text-sm font-bold text-ctp-text">Pending Bots</h3>
+      {pendingBots.length === 0 ? (
+        <p className="text-xs text-ctp-subtext0">No bots awaiting approval.</p>
+      ) : (
+        <div className="max-h-64 space-y-2 overflow-auto pr-1">
+          {pendingBots.map((bot) => (
+            <div
+              key={bot.pubkey}
+              className="flex items-center justify-between rounded-lg border border-ctp-surface1 bg-ctp-base/70 p-2"
+            >
+              <div>
+                <div className="flex items-center gap-1">
+                  <span className="text-xs font-semibold text-ctp-text">
+                    {truncatePubkey(bot.pubkey)}
+                  </span>
+                  <span className="rounded bg-ctp-yellow/20 px-1 py-0.5 text-[10px] font-bold text-ctp-yellow">
+                    PENDING
+                  </span>
+                </div>
+              </div>
+              <div className="flex gap-1">
+                <button
+                  onClick={() => { void onApprove(bot.pubkey); }}
+                  className="rounded-md border border-ctp-green/40 bg-ctp-green/10 px-2 py-1 text-xs text-ctp-green hover:bg-ctp-green/20"
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => { void onRevoke(bot.pubkey); }}
+                  className="rounded-md border border-ctp-red/40 bg-ctp-red/10 px-2 py-1 text-xs text-ctp-red hover:bg-ctp-red/20"
+                >
+                  Reject
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/stores/members.ts
+++ b/client/src/stores/members.ts
@@ -151,7 +151,7 @@ export const useMembersStore = create<MembersStore>((set) => ({
     set((state) => {
       switch (event.op) {
         case "MEMBER_JOIN": {
-          const payload = event.d as { user_id: string; pubkey: string; joined_at: string; is_bot?: boolean; roles?: { id: string; name: string; color: string | null; position: number }[] };
+          const payload = event.d as { user_id: string; pubkey: string; display_name?: string | null; avatar_hash?: string | null; joined_at: string; is_bot?: boolean; roles?: { id: string; name: string; color: string | null; position: number }[] };
           const existing = state.members.find((member) => member.user_id === payload.user_id);
           if (existing) {
             return {};
@@ -162,6 +162,8 @@ export const useMembersStore = create<MembersStore>((set) => ({
               {
                 user_id: payload.user_id,
                 pubkey: payload.pubkey,
+                display_name: payload.display_name ?? null,
+                avatar_hash: payload.avatar_hash ?? null,
                 joined_at: payload.joined_at,
                 is_bot: payload.is_bot ?? false,
                 roles: payload.roles ?? [],

--- a/client/src/stores/members.ts
+++ b/client/src/stores/members.ts
@@ -2,15 +2,19 @@ import { create } from "zustand";
 
 import {
   addAllowlist,
+  approveBot,
   banMember,
   kickMember,
   listAllowlist,
   listBans,
   listMembers,
+  listPendingBots,
   removeAllowlist,
+  revokeBot,
   unbanMember,
   type AllowlistEntry,
   type Ban,
+  type BotApproval,
   type Member,
 } from "../api/members";
 
@@ -18,16 +22,20 @@ interface MembersStore {
   members: Member[];
   bans: Ban[];
   allowlist: AllowlistEntry[];
+  pendingBots: BotApproval[];
   loading: boolean;
   error: string | null;
   fetchMembers: (baseUrl: string, token: string) => Promise<void>;
   fetchBans: (baseUrl: string, token: string) => Promise<void>;
   fetchAllowlist: (baseUrl: string, token: string) => Promise<void>;
+  fetchPendingBots: (baseUrl: string, token: string) => Promise<void>;
   kick: (baseUrl: string, token: string, pubkey: string) => Promise<void>;
   ban: (baseUrl: string, token: string, pubkey: string, reason?: string) => Promise<void>;
   unban: (baseUrl: string, token: string, pubkey: string) => Promise<void>;
   addAllowlistEntry: (baseUrl: string, token: string, pubkey: string) => Promise<void>;
   removeAllowlistEntry: (baseUrl: string, token: string, pubkey: string) => Promise<void>;
+  approveBotEntry: (baseUrl: string, token: string, pubkey: string, note?: string) => Promise<void>;
+  revokeBotEntry: (baseUrl: string, token: string, pubkey: string) => Promise<void>;
   updateMemberProfile: (
     userId: string,
     patch: { display_name?: string | null; avatar_hash?: string | null },
@@ -40,6 +48,7 @@ export const useMembersStore = create<MembersStore>((set) => ({
   members: [],
   bans: [],
   allowlist: [],
+  pendingBots: [],
   loading: false,
   error: null,
 
@@ -101,6 +110,27 @@ export const useMembersStore = create<MembersStore>((set) => ({
   removeAllowlistEntry: async (baseUrl, token, pubkey) => {
     await removeAllowlist(baseUrl, token, pubkey);
     set((state) => ({ allowlist: state.allowlist.filter((entry) => entry.pubkey !== pubkey) }));
+  },
+
+  fetchPendingBots: async (baseUrl, token) => {
+    set({ loading: true, error: null });
+    try {
+      const pendingBots = await listPendingBots(baseUrl, token);
+      set({ pendingBots, loading: false });
+    } catch (error) {
+      set({ loading: false, error: error instanceof Error ? error.message : String(error) });
+    }
+  },
+
+  approveBotEntry: async (baseUrl, token, pubkey, note) => {
+    await approveBot(baseUrl, token, pubkey, note);
+    set((state) => ({
+      pendingBots: state.pendingBots.filter((bot) => bot.pubkey !== pubkey),
+    }));
+  },
+
+  revokeBotEntry: async (baseUrl, token, pubkey) => {
+    await revokeBot(baseUrl, token, pubkey);
   },
 
   updateMemberProfile: (userId, patch) => {
@@ -176,6 +206,6 @@ export const useMembersStore = create<MembersStore>((set) => ({
   },
 
   clear: () => {
-    set({ members: [], bans: [], allowlist: [], loading: false, error: null });
+    set({ members: [], bans: [], allowlist: [], pendingBots: [], loading: false, error: null });
   },
 }));

--- a/client/src/stores/members.ts
+++ b/client/src/stores/members.ts
@@ -154,7 +154,19 @@ export const useMembersStore = create<MembersStore>((set) => ({
           const payload = event.d as { user_id: string; pubkey: string; display_name?: string | null; avatar_hash?: string | null; joined_at: string; is_bot?: boolean; roles?: { id: string; name: string; color: string | null; position: number }[] };
           const existing = state.members.find((member) => member.user_id === payload.user_id);
           if (existing) {
-            return {};
+            // Update profile fields in case they arrived incomplete in an earlier event.
+            return {
+              members: state.members.map((m) =>
+                m.user_id === payload.user_id
+                  ? {
+                      ...m,
+                      display_name: payload.display_name ?? m.display_name,
+                      avatar_hash: payload.avatar_hash ?? m.avatar_hash,
+                      is_bot: payload.is_bot ?? m.is_bot,
+                    }
+                  : m,
+              ),
+            };
           }
           return {
             members: [

--- a/client/src/stores/members.ts
+++ b/client/src/stores/members.ts
@@ -151,7 +151,7 @@ export const useMembersStore = create<MembersStore>((set) => ({
     set((state) => {
       switch (event.op) {
         case "MEMBER_JOIN": {
-          const payload = event.d as { user_id: string; pubkey: string; joined_at: string; roles?: { id: string; name: string; color: string | null; position: number }[] };
+          const payload = event.d as { user_id: string; pubkey: string; joined_at: string; is_bot?: boolean; roles?: { id: string; name: string; color: string | null; position: number }[] };
           const existing = state.members.find((member) => member.user_id === payload.user_id);
           if (existing) {
             return {};
@@ -163,6 +163,7 @@ export const useMembersStore = create<MembersStore>((set) => ({
                 user_id: payload.user_id,
                 pubkey: payload.pubkey,
                 joined_at: payload.joined_at,
+                is_bot: payload.is_bot ?? false,
                 roles: payload.roles ?? [],
               },
             ],

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -476,9 +476,9 @@ export const useServerStore = create<ServerStore>((set, get) => ({
           };
         }
         case "MEMBER_JOIN": {
-          const member = event.d as { user_id: string; pubkey: string; roles: string[]; joined_at: string };
+          const member = event.d as { user_id: string; pubkey: string; roles?: string[]; joined_at: string };
           const existing = state.memberRoleIdsByUserId[member.user_id] ?? [];
-          const merged = Array.from(new Set([...existing, ...member.roles]));
+          const merged = Array.from(new Set([...existing, ...(member.roles ?? [])]));
           useMembersStore.getState().applyGatewayEvent(event);
           return {
             memberRoleIdsByUserId: {

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -6,6 +6,7 @@ import type { Attachment } from "../api/media";
 import type { ReactionSummary } from "../api/reactions";
 import type { ChannelPermissionOverride, Role } from "../api/roles";
 import { listRoles } from "../api/roles";
+import { getServerInfo } from "../api/server";
 import { ApiError, apiRequest } from "../services/api";
 import { authenticateServer } from "../services/auth";
 import { GatewayClient } from "../services/gateway";
@@ -85,6 +86,7 @@ export interface ServerStore {
   status: ConnectionStatus;
   sessionToken: string | null;
   sessionUserId: string | null;
+  membershipMode: string;
   channels: Channel[];
   roles: Role[];
   memberRoleIdsByUserId: Record<string, string[]>;
@@ -143,6 +145,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
   status: "disconnected",
   sessionToken: null,
   sessionUserId: null,
+  membershipMode: "",
   channels: [],
   roles: [],
   memberRoleIdsByUserId: {},
@@ -159,8 +162,15 @@ export const useServerStore = create<ServerStore>((set, get) => ({
     set({ status: "connecting", error: null, address: normalized, serverId: normalized });
 
     try {
-      const session = await authenticateServer(normalized);
-      set({ sessionToken: session.token, sessionUserId: session.userId });
+      const [session, serverInfo] = await Promise.all([
+        authenticateServer(normalized),
+        getServerInfo(normalized),
+      ]);
+      set({
+        sessionToken: session.token,
+        sessionUserId: session.userId,
+        membershipMode: serverInfo.membership_mode,
+      });
 
       let channelData;
       try {

--- a/server/migrations/009_bots.sql
+++ b/server/migrations/009_bots.sql
@@ -1,0 +1,11 @@
+ALTER TABLE users ADD COLUMN is_bot INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE bot_approvals (
+    pubkey      TEXT PRIMARY KEY,
+    approved_by TEXT REFERENCES users(id),
+    approved_at TEXT,
+    revoked_at  TEXT,
+    note        TEXT
+);
+
+ALTER TABLE sessions ADD COLUMN is_read_only INTEGER NOT NULL DEFAULT 0;

--- a/server/src/auth/challenge.rs
+++ b/server/src/auth/challenge.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 #[derive(Debug, Clone)]
 struct ChallengeEntry {
     nonce: Vec<u8>,
+    is_bot: bool,
     expires_at: Instant,
 }
 
@@ -24,32 +25,33 @@ impl ChallengeStore {
         }
     }
 
-    pub fn insert(&self, pubkey: String, nonce: Vec<u8>) {
+    pub fn insert(&self, pubkey: String, nonce: Vec<u8>, is_bot: bool) {
         self.entries.insert(
             pubkey,
             ChallengeEntry {
                 nonce,
+                is_bot,
                 expires_at: Instant::now() + self.ttl,
             },
         );
     }
 
-    pub fn get(&self, pubkey: &str) -> Option<Vec<u8>> {
+    pub fn get(&self, pubkey: &str) -> Option<(Vec<u8>, bool)> {
         let entry = self.entries.get(pubkey)?;
         if entry.expires_at <= Instant::now() {
             drop(entry);
             self.entries.remove(pubkey);
             return None;
         }
-        Some(entry.nonce.clone())
+        Some((entry.nonce.clone(), entry.is_bot))
     }
 
-    pub fn take(&self, pubkey: &str) -> Option<Vec<u8>> {
+    pub fn take(&self, pubkey: &str) -> Option<(Vec<u8>, bool)> {
         let (.., entry) = self.entries.remove(pubkey)?;
         if entry.expires_at <= Instant::now() {
             return None;
         }
-        Some(entry.nonce)
+        Some((entry.nonce, entry.is_bot))
     }
 
     pub fn purge_expired(&self) -> usize {
@@ -75,16 +77,26 @@ mod tests {
     fn challenge_store_creates_and_retrieves_challenges() {
         let store = ChallengeStore::new(Duration::from_secs(300));
         let nonce = vec![1u8; 32];
-        store.insert("pk1".to_string(), nonce.clone());
+        store.insert("pk1".to_string(), nonce.clone(), false);
 
         let got = store.get("pk1");
-        assert_eq!(got, Some(nonce));
+        assert_eq!(got, Some((nonce, false)));
+    }
+
+    #[test]
+    fn challenge_store_preserves_is_bot_flag() {
+        let store = ChallengeStore::new(Duration::from_secs(300));
+        let nonce = vec![2u8; 32];
+        store.insert("bot1".to_string(), nonce.clone(), true);
+
+        let got = store.get("bot1");
+        assert_eq!(got, Some((nonce, true)));
     }
 
     #[test]
     fn purge_expired_removes_stale_entries() {
         let store = ChallengeStore::new(Duration::from_millis(1));
-        store.insert("pk1".to_string(), vec![7u8; 32]);
+        store.insert("pk1".to_string(), vec![7u8; 32], false);
         std::thread::sleep(Duration::from_millis(5));
 
         let removed = store.purge_expired();
@@ -95,7 +107,7 @@ mod tests {
     #[test]
     fn challenges_are_single_use() {
         let store = ChallengeStore::new(Duration::from_secs(300));
-        store.insert("pk1".to_string(), vec![9u8; 32]);
+        store.insert("pk1".to_string(), vec![9u8; 32], false);
 
         assert!(store.take("pk1").is_some());
         assert!(store.take("pk1").is_none());

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -22,6 +22,17 @@ pub(super) struct ErrorBody {
 
 type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorBody>)>;
 
+/// Challenge text for a given nonce and is_bot flag.
+/// Including the is_bot flag in the signed text binds the claim to the signature.
+pub(crate) fn challenge_text(nonce: &[u8], is_bot: bool) -> String {
+    let b64 = BASE64.encode(nonce);
+    if is_bot {
+        format!("{b64}|bot")
+    } else {
+        b64
+    }
+}
+
 pub(super) async fn challenge(
     State(state): State<AppState>,
     Json(req): Json<ChallengeRequest>,
@@ -33,10 +44,12 @@ pub(super) async fn challenge(
     let mut nonce = [0u8; 32];
     rand::rng().fill_bytes(&mut nonce);
 
-    state.challenge_store.insert(req.pubkey, nonce.to_vec());
+    state
+        .challenge_store
+        .insert(req.pubkey, nonce.to_vec(), req.is_bot);
 
     Ok(Json(ChallengeResponse {
-        challenge: BASE64.encode(nonce),
+        challenge: challenge_text(&nonce, req.is_bot),
     }))
 }
 
@@ -49,15 +62,14 @@ pub(super) async fn verify(
     let signature =
         parse_signature(&req.signature).map_err(|_| bad_request("invalid signature format"))?;
 
-    let nonce = state
+    let (nonce, is_bot) = state
         .challenge_store
         .take(&req.pubkey)
         .ok_or_else(|| unauthorized("challenge not found or expired"))?;
 
-    // The client signs the base64 challenge string it receives.
-    let challenge_text = BASE64.encode(nonce);
+    let text = challenge_text(&nonce, is_bot);
     verifying_key
-        .verify(challenge_text.as_bytes(), &signature)
+        .verify(text.as_bytes(), &signature)
         .map_err(|_| unauthorized("signature verification failed"))?;
 
     let mut created_user = false;
@@ -77,7 +89,7 @@ pub(super) async fn verify(
             created_user = true;
             state
                 .storage
-                .create_user(&req.pubkey, None)
+                .create_user(&req.pubkey, None, is_bot)
                 .await
                 .map_err(internal)?
         }
@@ -89,17 +101,32 @@ pub(super) async fn verify(
             let _ = state.storage.add_member(&user.id).await;
             let _ = state.storage.add_member_role(&user.id, "everyone").await;
             let _ = state.storage.add_member_role(&user.id, "admin").await;
-        } else if state.config.membership.mode == MembershipMode::Open {
+        } else if state.config.membership.mode == MembershipMode::Open && !is_bot {
             let _ = state.storage.add_member(&user.id).await;
             let _ = state.storage.add_member_role(&user.id, "everyone").await;
         }
+
+        if is_bot {
+            let _ = state.storage.upsert_bot_pending(&req.pubkey).await;
+        }
     }
+
+    let is_read_only = if user.is_bot {
+        !state
+            .storage
+            .is_bot_approved(&req.pubkey)
+            .await
+            .map_err(internal)?
+    } else {
+        false
+    };
 
     let session = state
         .storage
         .create_session(
             &user.id,
             Duration::from_secs(state.config.auth.session_ttl_seconds),
+            is_read_only,
         )
         .await
         .map_err(internal)?;
@@ -108,6 +135,7 @@ pub(super) async fn verify(
         token: session.token,
         user_id: user.id,
         expires_at: session.expires_at.to_rfc3339(),
+        is_read_only,
     }))
 }
 

--- a/server/src/auth/middleware.rs
+++ b/server/src/auth/middleware.rs
@@ -12,6 +12,7 @@ use crate::AppState;
 #[derive(Debug, Clone)]
 pub struct AuthUser {
     pub user_id: String,
+    pub is_read_only: bool,
 }
 
 #[derive(Debug)]
@@ -84,6 +85,7 @@ where
 
         Ok(AuthUser {
             user_id: session.user_id,
+            is_read_only: session.is_read_only,
         })
     }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -60,7 +60,7 @@ pub struct FeatureFlags {
     pub message_search: bool,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum MembershipMode {
     Open,

--- a/server/src/invites/handlers.rs
+++ b/server/src/invites/handlers.rs
@@ -8,6 +8,7 @@ use shared::gateway::Op;
 use crate::auth::middleware::AuthUser;
 use crate::gateway::events::event_json;
 use crate::invites::{build_invite_link, generate_code};
+use crate::membership::handlers::member_to_response;
 use crate::invites::models::{
     CreateInviteRequest, InvitePreviewResponse, InviteResponse, JoinInviteResponse, JoinedMember,
     ListInvitesResponse,
@@ -321,16 +322,12 @@ pub(super) async fn join_invite(
     };
 
     if !already_member {
-        if let Some(msg) = event_json(
-            Op::MemberJoin,
-            serde_json::json!({
-                "user_id": user.id,
-                "pubkey": user.pubkey,
-                "roles": role_ids,
-                "joined_at": joined_at,
-            }),
-        ) {
-            state.gateway.broadcast_all(&msg);
+        if let Ok(Some(m)) = state.storage.get_member_by_pubkey(&user.pubkey).await {
+            if let Ok(full) = member_to_response(&state, m).await {
+                if let Some(msg) = event_json(Op::MemberJoin, full) {
+                    state.gateway.broadcast_all(&msg);
+                }
+            }
         }
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -298,10 +298,10 @@ mod tests {
     /// Full bot lifecycle:
     ///   1. Admin authenticates (first user → auto-granted admin).
     ///   2. Bot authenticates with is_bot=true → read-only session, queued in bot_approvals.
-    ///   3. Bot joins the server (Open mode allows it).
-    ///   4. Bot tries to send a message → blocked (read-only).
-    ///   5. Admin lists pending bots → bot appears.
-    ///   6. Admin approves the bot.
+    ///   3. Bot tries to send a message → 403 (not a member yet).
+    ///   4. Admin lists pending bots → bot appears.
+    ///   5. Admin approves the bot → bot is auto-joined as a member.
+    ///   6. Bot appears in the member list with is_bot=true.
     ///   7. Bot re-authenticates → non-read-only session.
     ///   8. Bot sends a message → succeeds.
     ///   9. Verify DB state: approval recorded, message authored by bot.
@@ -330,41 +330,23 @@ mod tests {
         assert_eq!(pending[0].pubkey, bot_pubkey);
         assert!(pending[0].approved_at.is_none(), "should still be pending");
 
-        // Step 3: Bot joins the server (Open mode).
-        let (join_status, join_body) = post(&state, "/api/v1/members/join", &bot_auth1.token, "").await;
-        assert_eq!(
-            join_status,
-            StatusCode::OK,
-            "bot should be able to join an open server: {}",
-            String::from_utf8_lossy(&join_body)
-        );
-
-        // Step 4: Bot tries to send a message — must be blocked.
-        let (send_status, send_body) = post(
+        // Step 3: Bot tries to send a message before being approved — not a member yet.
+        let (send_status, _) = post(
             &state,
             &format!("/api/v1/channels/{channel_id}/messages"),
             &bot_auth1.token,
             r#"{"content":"hello from unapproved bot"}"#,
         )
         .await;
-        assert_eq!(send_status, StatusCode::FORBIDDEN);
-        let body_str = String::from_utf8_lossy(&send_body);
-        assert!(
-            body_str.contains("read-only"),
-            "error should mention read-only: {body_str}"
-        );
+        assert_eq!(send_status, StatusCode::FORBIDDEN, "unapproved bot must be blocked");
 
-        // Step 5: Admin lists pending bots — bot should appear.
+        // Step 4: Admin lists pending bots — bot should appear.
         let (list_status, list_body) = get(&state, "/api/v1/admin/bots/pending", &admin.token).await;
         assert_eq!(list_status, StatusCode::OK);
         let pending_json: serde_json::Value = serde_json::from_slice(&list_body).unwrap();
-        assert_eq!(
-            pending_json["bots"].as_array().unwrap().len(),
-            1,
-            "one bot awaiting approval"
-        );
+        assert_eq!(pending_json["bots"].as_array().unwrap().len(), 1, "one bot awaiting approval");
 
-        // Step 6: Admin approves the bot.
+        // Step 5: Admin approves the bot — should auto-join the bot as a member.
         let (approve_status, approve_body) = post(
             &state,
             &format!("/api/v1/admin/bots/{bot_pubkey}/approve"),
@@ -388,12 +370,16 @@ mod tests {
         let pending_after = state.storage.list_pending_bots().await.unwrap();
         assert!(pending_after.is_empty(), "no bots pending after approval");
 
+        // Step 6: Bot should now be a member with is_bot=true.
+        let is_member = state.storage.is_member(&bot_auth1.user_id).await.unwrap();
+        assert!(is_member, "bot should be auto-joined as a member on approval");
+        let members = state.storage.list_members().await.unwrap();
+        let bot_member = members.iter().find(|m| m.user_id == bot_auth1.user_id).unwrap();
+        assert!(bot_member.is_bot, "member record should carry is_bot=true");
+
         // Step 7: Bot re-authenticates — should now get a non-read-only session.
         let bot_auth2 = do_auth(&state, 0x10, true).await;
-        assert!(
-            !bot_auth2.is_read_only,
-            "approved bot should get a normal (non-read-only) session"
-        );
+        assert!(!bot_auth2.is_read_only, "approved bot should get a normal (non-read-only) session");
         assert_eq!(bot_auth2.user_id, bot_auth1.user_id, "same user_id on re-auth");
 
         // Step 8: Bot sends a message with the new session.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -196,6 +196,9 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::Engine;
+    use ed25519_dalek::Signer;
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
@@ -207,6 +210,217 @@ mod tests {
             challenge_store: auth::challenge_store(),
             gateway: gateway::gateway_handle(),
         }
+    }
+
+    /// Perform challenge-response auth. Returns the full VerifyResponse.
+    /// Set `is_bot = true` to send the bot claim in the challenge request.
+    async fn do_auth(state: &AppState, seed: u8, is_bot: bool) -> shared::auth::VerifyResponse {
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[seed; 32]);
+        let pubkey = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
+
+        let challenge_resp = app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/challenge")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "pubkey": pubkey, "is_bot": is_bot }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let challenge: shared::auth::ChallengeResponse =
+            serde_json::from_slice(&challenge_resp.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+
+        let signature = BASE64.encode(signing_key.sign(challenge.challenge.as_bytes()).to_bytes());
+        let verify_resp = app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/verify")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "pubkey": pubkey, "signature": signature }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        serde_json::from_slice(&verify_resp.into_body().collect().await.unwrap().to_bytes())
+            .unwrap()
+    }
+
+    /// POST a request with a Bearer token and JSON body. Returns (status, body bytes).
+    async fn post(
+        state: &AppState,
+        uri: &str,
+        token: &str,
+        body: &str,
+    ) -> (StatusCode, Vec<u8>) {
+        let resp = app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body = resp.into_body().collect().await.unwrap().to_bytes().to_vec();
+        (status, body)
+    }
+
+    /// GET with a Bearer token. Returns (status, body bytes).
+    async fn get(state: &AppState, uri: &str, token: &str) -> (StatusCode, Vec<u8>) {
+        let resp = app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body = resp.into_body().collect().await.unwrap().to_bytes().to_vec();
+        (status, body)
+    }
+
+    /// Full bot lifecycle:
+    ///   1. Admin authenticates (first user → auto-granted admin).
+    ///   2. Bot authenticates with is_bot=true → read-only session, queued in bot_approvals.
+    ///   3. Bot joins the server (Open mode allows it).
+    ///   4. Bot tries to send a message → blocked (read-only).
+    ///   5. Admin lists pending bots → bot appears.
+    ///   6. Admin approves the bot.
+    ///   7. Bot re-authenticates → non-read-only session.
+    ///   8. Bot sends a message → succeeds.
+    ///   9. Verify DB state: approval recorded, message authored by bot.
+    #[tokio::test]
+    async fn bot_approval_flow() {
+        let state = test_state().await;
+
+        // Create a channel for message tests.
+        let channel_id = state.storage.create_channel("general", None, 0).await.unwrap().id;
+
+        // Step 1: Admin authenticates. First user is auto-granted admin in Open mode.
+        let admin = do_auth(&state, 0x01, false).await;
+        assert!(!admin.is_read_only, "admin should not be read-only");
+
+        // Step 2: Bot authenticates with is_bot=true.
+        let bot_pubkey = {
+            let sk = ed25519_dalek::SigningKey::from_bytes(&[0x10u8; 32]);
+            bs58::encode(sk.verifying_key().as_bytes()).into_string()
+        };
+        let bot_auth1 = do_auth(&state, 0x10, true).await;
+        assert!(bot_auth1.is_read_only, "unapproved bot must receive a read-only session");
+
+        // bot_approvals should have a pending row with no approved_at.
+        let pending = state.storage.list_pending_bots().await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].pubkey, bot_pubkey);
+        assert!(pending[0].approved_at.is_none(), "should still be pending");
+
+        // Step 3: Bot joins the server (Open mode).
+        let (join_status, join_body) = post(&state, "/api/v1/members/join", &bot_auth1.token, "").await;
+        assert_eq!(
+            join_status,
+            StatusCode::OK,
+            "bot should be able to join an open server: {}",
+            String::from_utf8_lossy(&join_body)
+        );
+
+        // Step 4: Bot tries to send a message — must be blocked.
+        let (send_status, send_body) = post(
+            &state,
+            &format!("/api/v1/channels/{channel_id}/messages"),
+            &bot_auth1.token,
+            r#"{"content":"hello from unapproved bot"}"#,
+        )
+        .await;
+        assert_eq!(send_status, StatusCode::FORBIDDEN);
+        let body_str = String::from_utf8_lossy(&send_body);
+        assert!(
+            body_str.contains("read-only"),
+            "error should mention read-only: {body_str}"
+        );
+
+        // Step 5: Admin lists pending bots — bot should appear.
+        let (list_status, list_body) = get(&state, "/api/v1/admin/bots/pending", &admin.token).await;
+        assert_eq!(list_status, StatusCode::OK);
+        let pending_json: serde_json::Value = serde_json::from_slice(&list_body).unwrap();
+        assert_eq!(
+            pending_json["bots"].as_array().unwrap().len(),
+            1,
+            "one bot awaiting approval"
+        );
+
+        // Step 6: Admin approves the bot.
+        let (approve_status, approve_body) = post(
+            &state,
+            &format!("/api/v1/admin/bots/{bot_pubkey}/approve"),
+            &admin.token,
+            r#"{}"#,
+        )
+        .await;
+        assert_eq!(
+            approve_status,
+            StatusCode::OK,
+            "approve should succeed: {}",
+            String::from_utf8_lossy(&approve_body)
+        );
+
+        // bot_approvals row should now have approved_at set.
+        let approval = state.storage.get_bot_approval(&bot_pubkey).await.unwrap().unwrap();
+        assert!(approval.approved_at.is_some(), "approved_at must be set after approval");
+        assert!(approval.revoked_at.is_none(), "revoked_at must be empty");
+
+        // Pending list should now be empty.
+        let pending_after = state.storage.list_pending_bots().await.unwrap();
+        assert!(pending_after.is_empty(), "no bots pending after approval");
+
+        // Step 7: Bot re-authenticates — should now get a non-read-only session.
+        let bot_auth2 = do_auth(&state, 0x10, true).await;
+        assert!(
+            !bot_auth2.is_read_only,
+            "approved bot should get a normal (non-read-only) session"
+        );
+        assert_eq!(bot_auth2.user_id, bot_auth1.user_id, "same user_id on re-auth");
+
+        // Step 8: Bot sends a message with the new session.
+        let (msg_status, msg_body) = post(
+            &state,
+            &format!("/api/v1/channels/{channel_id}/messages"),
+            &bot_auth2.token,
+            r#"{"content":"hello from approved bot"}"#,
+        )
+        .await;
+        assert_eq!(
+            msg_status,
+            StatusCode::OK,
+            "approved bot should be able to send messages: {}",
+            String::from_utf8_lossy(&msg_body)
+        );
+
+        // Step 9: Verify DB state — message is authored by the bot.
+        let msg_json: serde_json::Value = serde_json::from_slice(&msg_body).unwrap();
+        assert_eq!(msg_json["author_id"], bot_auth1.user_id);
+        assert_eq!(msg_json["content"], "hello from approved bot");
+
+        let messages = state.storage.list_messages(&channel_id, None, 50).await.unwrap();
+        assert!(
+            messages.iter().any(|m| m.author_id == bot_auth1.user_id),
+            "message authored by bot must be in DB"
+        );
     }
 
     #[tokio::test]

--- a/server/src/membership/handlers.rs
+++ b/server/src/membership/handlers.rs
@@ -76,7 +76,7 @@ fn is_valid_pubkey(pubkey: &str) -> bool {
         .unwrap_or(false)
 }
 
-async fn member_to_response(
+pub(crate) async fn member_to_response(
     state: &AppState,
     member: Member,
 ) -> Result<MemberWithRoles, crate::storage::StorageError> {
@@ -195,19 +195,12 @@ pub(super) async fn join_member(
             let _ = state.storage.add_member_role(&auth.user_id, "admin").await;
         }
 
-        if let Some(msg) = event_json(
-            Op::MemberJoin,
-            serde_json::json!({
-                "user_id": user.id,
-                "pubkey": user.pubkey,
-                "display_name": user.display_name,
-                "avatar_hash": user.avatar_hash,
-                "is_bot": user.is_bot,
-                "joined_at": Utc::now(),
-                "roles": [],
-            }),
-        ) {
-            state.gateway.broadcast_all(&msg);
+        if let Ok(Some(m)) = state.storage.get_member_by_pubkey(&user.pubkey).await {
+            if let Ok(full) = member_to_response(&state, m).await {
+                if let Some(msg) = event_json(Op::MemberJoin, full) {
+                    state.gateway.broadcast_all(&msg);
+                }
+            }
         }
     }
 
@@ -530,17 +523,12 @@ pub(super) async fn approve_bot(
             let _ = state.storage.add_member(&user.id).await;
             let _ = state.storage.add_member_role(&user.id, "everyone").await;
 
-            if let Some(msg) = event_json(
-                Op::MemberJoin,
-                serde_json::json!({
-                    "user_id": user.id,
-                    "pubkey": user.pubkey,
-                    "is_bot": user.is_bot,
-                    "joined_at": Utc::now(),
-                    "roles": [],
-                }),
-            ) {
-                state.gateway.broadcast_all(&msg);
+            if let Ok(Some(m)) = state.storage.get_member_by_pubkey(&pubkey).await {
+                if let Ok(full) = member_to_response(&state, m).await {
+                    if let Some(msg) = event_json(Op::MemberJoin, full) {
+                        state.gateway.broadcast_all(&msg);
+                    }
+                }
             }
         }
     }

--- a/server/src/membership/handlers.rs
+++ b/server/src/membership/handlers.rs
@@ -200,6 +200,8 @@ pub(super) async fn join_member(
             serde_json::json!({
                 "user_id": user.id,
                 "pubkey": user.pubkey,
+                "display_name": user.display_name,
+                "avatar_hash": user.avatar_hash,
                 "is_bot": user.is_bot,
                 "joined_at": Utc::now(),
                 "roles": [],

--- a/server/src/membership/handlers.rs
+++ b/server/src/membership/handlers.rs
@@ -200,7 +200,9 @@ pub(super) async fn join_member(
             serde_json::json!({
                 "user_id": user.id,
                 "pubkey": user.pubkey,
+                "is_bot": user.is_bot,
                 "joined_at": Utc::now(),
+                "roles": [],
             }),
         ) {
             state.gateway.broadcast_all(&msg);
@@ -531,7 +533,9 @@ pub(super) async fn approve_bot(
                 serde_json::json!({
                     "user_id": user.id,
                     "pubkey": user.pubkey,
+                    "is_bot": user.is_bot,
                     "joined_at": Utc::now(),
+                    "roles": [],
                 }),
             ) {
                 state.gateway.broadcast_all(&msg);

--- a/server/src/membership/handlers.rs
+++ b/server/src/membership/handlers.rs
@@ -9,8 +9,9 @@ use crate::auth::middleware::AuthUser;
 use crate::config::MembershipMode;
 use crate::gateway::events::event_json;
 use crate::membership::models::{
-    AllowlistRequest, AllowlistEntryResponse, BanRequest, BanResponse, JoinMemberResponse,
-    ListAllowlistResponse, ListBansResponse, ListMembersResponse, MemberWithRoles, RoleSummary,
+    AllowlistRequest, AllowlistEntryResponse, ApproveBotRequest, BotApprovalResponse, BanRequest,
+    BanResponse, JoinMemberResponse, ListAllowlistResponse, ListBansResponse, ListMembersResponse,
+    ListPendingBotsResponse, MemberWithRoles, RoleSummary,
 };
 use crate::permissions::{MemberUser, UserPermissions, ADMINISTRATOR, BAN_MEMBERS, KICK_MEMBERS, MANAGE_SERVER};
 use crate::storage::models::Member;
@@ -92,6 +93,7 @@ async fn member_to_response(
         pubkey: member.pubkey,
         display_name: member.display_name,
         avatar_hash: member.avatar_hash,
+        is_bot: member.is_bot,
         joined_at: member.joined_at,
         roles,
     })
@@ -480,5 +482,62 @@ pub(super) async fn remove_allowlist(
         .await
         .map_err(storage_err)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+pub(super) async fn list_pending_bots(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+) -> ApiResult<ListPendingBotsResponse> {
+    if !auth.has(MANAGE_SERVER) {
+        return Err(forbidden("missing manage_server permission"));
+    }
+
+    let bots = state
+        .storage
+        .list_pending_bots()
+        .await
+        .map_err(internal)?
+        .into_iter()
+        .map(BotApprovalResponse::from)
+        .collect();
+
+    Ok(Json(ListPendingBotsResponse { bots }))
+}
+
+pub(super) async fn approve_bot(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path(pubkey): Path<String>,
+    Json(req): Json<ApproveBotRequest>,
+) -> ApiResult<BotApprovalResponse> {
+    if !auth.has(MANAGE_SERVER) {
+        return Err(forbidden("missing manage_server permission"));
+    }
+
+    let approval = state
+        .storage
+        .approve_bot(&pubkey, &auth.user_id, req.note.as_deref())
+        .await
+        .map_err(storage_err)?;
+
+    Ok(Json(BotApprovalResponse::from(approval)))
+}
+
+pub(super) async fn revoke_bot(
+    State(state): State<AppState>,
+    auth: UserPermissions,
+    Path(pubkey): Path<String>,
+) -> ApiResult<BotApprovalResponse> {
+    if !auth.has(MANAGE_SERVER) {
+        return Err(forbidden("missing manage_server permission"));
+    }
+
+    let approval = state
+        .storage
+        .revoke_bot(&pubkey)
+        .await
+        .map_err(storage_err)?;
+
+    Ok(Json(BotApprovalResponse::from(approval)))
 }
 

--- a/server/src/membership/handlers.rs
+++ b/server/src/membership/handlers.rs
@@ -520,6 +520,25 @@ pub(super) async fn approve_bot(
         .await
         .map_err(storage_err)?;
 
+    // Auto-join: add the bot as a member so it's immediately visible in the member list.
+    if let Some(user) = state.storage.get_user_by_pubkey(&pubkey).await.map_err(internal)? {
+        if !state.storage.is_member(&user.id).await.map_err(internal)? {
+            let _ = state.storage.add_member(&user.id).await;
+            let _ = state.storage.add_member_role(&user.id, "everyone").await;
+
+            if let Some(msg) = event_json(
+                Op::MemberJoin,
+                serde_json::json!({
+                    "user_id": user.id,
+                    "pubkey": user.pubkey,
+                    "joined_at": Utc::now(),
+                }),
+            ) {
+                state.gateway.broadcast_all(&msg);
+            }
+        }
+    }
+
     Ok(Json(BotApprovalResponse::from(approval)))
 }
 

--- a/server/src/membership/mod.rs
+++ b/server/src/membership/mod.rs
@@ -1,4 +1,4 @@
-mod handlers;
+pub(crate) mod handlers;
 pub mod models;
 
 use axum::routing::{delete, get, post};

--- a/server/src/membership/mod.rs
+++ b/server/src/membership/mod.rs
@@ -21,6 +21,9 @@ pub fn router() -> Router<AppState> {
             get(handlers::list_allowlist).post(handlers::add_allowlist),
         )
         .route("/allowlist/:pubkey", delete(handlers::remove_allowlist))
+        .route("/admin/bots/pending", get(handlers::list_pending_bots))
+        .route("/admin/bots/:pubkey/approve", post(handlers::approve_bot))
+        .route("/admin/bots/:pubkey/revoke", post(handlers::revoke_bot))
 }
 
 #[cfg(test)]

--- a/server/src/membership/models.rs
+++ b/server/src/membership/models.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::storage::models::{AllowlistEntry, Ban, Role};
+use crate::storage::models::{AllowlistEntry, Ban, BotApproval, Role};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct BanRequest {
@@ -19,6 +19,7 @@ pub struct MemberWithRoles {
     pub pubkey: String,
     pub display_name: Option<String>,
     pub avatar_hash: Option<String>,
+    pub is_bot: bool,
     pub joined_at: DateTime<Utc>,
     pub roles: Vec<RoleSummary>,
 }
@@ -66,6 +67,25 @@ pub struct ListAllowlistResponse {
     pub entries: Vec<AllowlistEntryResponse>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct BotApprovalResponse {
+    pub pubkey: String,
+    pub approved_by: Option<String>,
+    pub approved_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ListPendingBotsResponse {
+    pub bots: Vec<BotApprovalResponse>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApproveBotRequest {
+    pub note: Option<String>,
+}
+
 impl From<Role> for RoleSummary {
     fn from(value: Role) -> Self {
         Self {
@@ -94,6 +114,18 @@ impl From<AllowlistEntry> for AllowlistEntryResponse {
             pubkey: value.pubkey,
             added_by: value.added_by,
             added_at: value.added_at,
+        }
+    }
+}
+
+impl From<BotApproval> for BotApprovalResponse {
+    fn from(value: BotApproval) -> Self {
+        Self {
+            pubkey: value.pubkey,
+            approved_by: value.approved_by,
+            approved_at: value.approved_at,
+            revoked_at: value.revoked_at,
+            note: value.note,
         }
     }
 }

--- a/server/src/messages/handlers.rs
+++ b/server/src/messages/handlers.rs
@@ -139,6 +139,9 @@ pub(super) async fn create_message(
     Path(channel_id): Path<String>,
     Json(req): Json<CreateMessageRequest>,
 ) -> ApiResult<MessageResponse> {
+    if auth.is_read_only {
+        return Err(forbidden("read-only session: bot requires admin approval"));
+    }
     ensure_channel_exists(&state, &channel_id).await?;
     let perms = effective_permissions(state.storage.as_ref(), &auth.user_id, Some(&channel_id))
         .await

--- a/server/src/permissions.rs
+++ b/server/src/permissions.rs
@@ -32,6 +32,7 @@ pub struct MemberUser {
     pub user_id: String,
     pub permissions: i64,
     pub highest_role_position: i32,
+    pub is_read_only: bool,
 }
 
 impl MemberUser {
@@ -116,6 +117,7 @@ where
             user_id: auth.user_id,
             permissions,
             highest_role_position,
+            is_read_only: auth.is_read_only,
         })
     }
 }

--- a/server/src/server_info.rs
+++ b/server/src/server_info.rs
@@ -12,5 +12,9 @@ async fn get_server_info(State(state): State<AppState>) -> Json<ServerInfo> {
     Json(ServerInfo {
         name: state.config.server.name.clone(),
         description: state.config.server.description.clone(),
+        membership_mode: serde_json::to_value(state.config.membership.mode)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_owned))
+            .unwrap_or_default(),
     })
 }

--- a/server/src/storage/models.rs
+++ b/server/src/storage/models.rs
@@ -22,8 +22,18 @@ pub struct User {
     pub pubkey: String,
     pub display_name: Option<String>,
     pub avatar_hash: Option<String>,
+    pub is_bot: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BotApproval {
+    pub pubkey: String,
+    pub approved_by: Option<String>,
+    pub approved_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub note: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,6 +89,7 @@ pub struct ThreadSummary {
 pub struct Session {
     pub token: String,
     pub user_id: String,
+    pub is_read_only: bool,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
 }
@@ -115,6 +126,7 @@ pub struct Member {
     pub pubkey: String,
     pub display_name: Option<String>,
     pub avatar_hash: Option<String>,
+    pub is_bot: bool,
     pub joined_at: DateTime<Utc>,
 }
 

--- a/server/src/storage/sqlite/attachments.rs
+++ b/server/src/storage/sqlite/attachments.rs
@@ -118,7 +118,7 @@ mod tests {
     #[tokio::test]
     async fn create_and_get_attachment() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let user = s.create_user("pk1", None).await.unwrap();
+        let user = s.create_user("pk1", None, false).await.unwrap();
         let ch = s.create_channel("general", None, 0).await.unwrap();
 
         let att = s
@@ -147,7 +147,7 @@ mod tests {
     #[tokio::test]
     async fn associate_attachments_with_message() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let user = s.create_user("pk1", None).await.unwrap();
+        let user = s.create_user("pk1", None, false).await.unwrap();
         let ch = s.create_channel("general", None, 0).await.unwrap();
         let msg = s.create_message(&ch.id, &user.id, "hello", None).await.unwrap();
 
@@ -189,8 +189,8 @@ mod tests {
     #[tokio::test]
     async fn cannot_associate_others_attachment() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let user1 = s.create_user("pk1", None).await.unwrap();
-        let user2 = s.create_user("pk2", None).await.unwrap();
+        let user1 = s.create_user("pk1", None, false).await.unwrap();
+        let user2 = s.create_user("pk2", None, false).await.unwrap();
         let ch = s.create_channel("general", None, 0).await.unwrap();
         let msg = s.create_message(&ch.id, &user2.id, "hi", None).await.unwrap();
 
@@ -217,7 +217,7 @@ mod tests {
     #[tokio::test]
     async fn cannot_double_associate() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let user = s.create_user("pk1", None).await.unwrap();
+        let user = s.create_user("pk1", None, false).await.unwrap();
         let ch = s.create_channel("general", None, 0).await.unwrap();
         let msg1 = s.create_message(&ch.id, &user.id, "m1", None).await.unwrap();
         let msg2 = s.create_message(&ch.id, &user.id, "m2", None).await.unwrap();

--- a/server/src/storage/sqlite/bots.rs
+++ b/server/src/storage/sqlite/bots.rs
@@ -1,0 +1,165 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+
+use super::SqliteStorage;
+use crate::storage::models::BotApproval;
+use crate::storage::traits::BotStore;
+use crate::storage::StorageError;
+
+fn row_to_bot_approval(row: sqlx::sqlite::SqliteRow) -> Result<BotApproval, StorageError> {
+    Ok(BotApproval {
+        pubkey: row.try_get("pubkey")?,
+        approved_by: row.try_get("approved_by")?,
+        approved_at: row.try_get::<Option<DateTime<Utc>>, _>("approved_at")?,
+        revoked_at: row.try_get::<Option<DateTime<Utc>>, _>("revoked_at")?,
+        note: row.try_get("note")?,
+    })
+}
+
+#[async_trait]
+impl BotStore for SqliteStorage {
+    async fn upsert_bot_pending(&self, pubkey: &str) -> Result<BotApproval, StorageError> {
+        sqlx::query(
+            "INSERT INTO bot_approvals (pubkey) VALUES (?)
+             ON CONFLICT(pubkey) DO NOTHING",
+        )
+        .bind(pubkey)
+        .execute(self.pool())
+        .await?;
+
+        self.get_bot_approval(pubkey)
+            .await?
+            .ok_or(StorageError::NotFound)
+    }
+
+    async fn approve_bot(
+        &self,
+        pubkey: &str,
+        approved_by: &str,
+        note: Option<&str>,
+    ) -> Result<BotApproval, StorageError> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            "UPDATE bot_approvals
+             SET approved_by = ?, approved_at = ?, revoked_at = NULL, note = COALESCE(?, note)
+             WHERE pubkey = ?",
+        )
+        .bind(approved_by)
+        .bind(now)
+        .bind(note)
+        .bind(pubkey)
+        .execute(self.pool())
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(StorageError::NotFound);
+        }
+
+        self.get_bot_approval(pubkey)
+            .await?
+            .ok_or(StorageError::NotFound)
+    }
+
+    async fn revoke_bot(&self, pubkey: &str) -> Result<BotApproval, StorageError> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            "UPDATE bot_approvals
+             SET revoked_at = ?, approved_at = NULL, approved_by = NULL
+             WHERE pubkey = ?",
+        )
+        .bind(now)
+        .bind(pubkey)
+        .execute(self.pool())
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(StorageError::NotFound);
+        }
+
+        self.get_bot_approval(pubkey)
+            .await?
+            .ok_or(StorageError::NotFound)
+    }
+
+    async fn get_bot_approval(&self, pubkey: &str) -> Result<Option<BotApproval>, StorageError> {
+        let row = sqlx::query("SELECT * FROM bot_approvals WHERE pubkey = ?")
+            .bind(pubkey)
+            .fetch_optional(self.pool())
+            .await?;
+        row.map(row_to_bot_approval).transpose()
+    }
+
+    async fn list_pending_bots(&self) -> Result<Vec<BotApproval>, StorageError> {
+        let rows = sqlx::query(
+            "SELECT * FROM bot_approvals WHERE approved_at IS NULL AND revoked_at IS NULL
+             ORDER BY rowid ASC",
+        )
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter().map(row_to_bot_approval).collect()
+    }
+
+    async fn is_bot_approved(&self, pubkey: &str) -> Result<bool, StorageError> {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM bot_approvals
+             WHERE pubkey = ? AND approved_at IS NOT NULL AND revoked_at IS NULL",
+        )
+        .bind(pubkey)
+        .fetch_one(self.pool())
+        .await?;
+        Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::traits::UserStore;
+
+    #[tokio::test]
+    async fn bot_approval_lifecycle() {
+        let s = SqliteStorage::in_memory().await.unwrap();
+        let admin = s.create_user("pk-admin", None, false).await.unwrap();
+        let _bot = s.create_user("pk-bot", None, true).await.unwrap();
+
+        // Upsert as pending
+        let pending = s.upsert_bot_pending("pk-bot").await.unwrap();
+        assert!(pending.approved_at.is_none());
+        assert!(pending.revoked_at.is_none());
+
+        // Not approved yet
+        assert!(!s.is_bot_approved("pk-bot").await.unwrap());
+
+        // Shows in pending list
+        let pending_list = s.list_pending_bots().await.unwrap();
+        assert_eq!(pending_list.len(), 1);
+        assert_eq!(pending_list[0].pubkey, "pk-bot");
+
+        // Approve
+        let approved = s.approve_bot("pk-bot", &admin.id, Some("looks good")).await.unwrap();
+        assert!(approved.approved_at.is_some());
+        assert!(approved.revoked_at.is_none());
+        assert!(s.is_bot_approved("pk-bot").await.unwrap());
+
+        // No longer in pending list
+        let pending_list = s.list_pending_bots().await.unwrap();
+        assert!(pending_list.is_empty());
+
+        // Revoke
+        let revoked = s.revoke_bot("pk-bot").await.unwrap();
+        assert!(revoked.revoked_at.is_some());
+        assert!(!s.is_bot_approved("pk-bot").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn upsert_bot_pending_is_idempotent() {
+        let s = SqliteStorage::in_memory().await.unwrap();
+        let _bot = s.create_user("pk-bot2", None, true).await.unwrap();
+
+        s.upsert_bot_pending("pk-bot2").await.unwrap();
+        s.upsert_bot_pending("pk-bot2").await.unwrap(); // should not fail
+        let pending_list = s.list_pending_bots().await.unwrap();
+        assert_eq!(pending_list.len(), 1);
+    }
+}

--- a/server/src/storage/sqlite/invites.rs
+++ b/server/src/storage/sqlite/invites.rs
@@ -129,7 +129,7 @@ mod tests {
     #[tokio::test]
     async fn code_can_be_created_and_listed() {
         let storage = SqliteStorage::in_memory().await.unwrap();
-        let creator = storage.create_user("pk-invite-creator", None).await.unwrap();
+        let creator = storage.create_user("pk-invite-creator", None, false).await.unwrap();
 
         let invite = storage
             .create_invite("abc12345", &creator.id, None, 1, None)
@@ -144,7 +144,7 @@ mod tests {
     #[tokio::test]
     async fn single_use_invite_exhausts() {
         let storage = SqliteStorage::in_memory().await.unwrap();
-        let creator = storage.create_user("pk-invite-consume", None).await.unwrap();
+        let creator = storage.create_user("pk-invite-consume", None, false).await.unwrap();
 
         storage
             .create_invite("consume01", &creator.id, None, 1, None)
@@ -163,7 +163,7 @@ mod tests {
     #[tokio::test]
     async fn expiry_is_checked() {
         let storage = SqliteStorage::in_memory().await.unwrap();
-        let creator = storage.create_user("pk-invite-expiry", None).await.unwrap();
+        let creator = storage.create_user("pk-invite-expiry", None, false).await.unwrap();
 
         let expires_at = Utc::now() - ChronoDuration::seconds(1);
         storage

--- a/server/src/storage/sqlite/media.rs
+++ b/server/src/storage/sqlite/media.rs
@@ -124,7 +124,7 @@ mod tests {
     #[tokio::test]
     async fn media_put_get_dedup() {
         let (s, _tmp) = storage_with_media().await;
-        let user = s.create_user("pk1", None).await.unwrap();
+        let user = s.create_user("pk1", None, false).await.unwrap();
 
         let id1 = s
             .put("abc123", "image/png", 100, &user.id, b"png data")

--- a/server/src/storage/sqlite/membership.rs
+++ b/server/src/storage/sqlite/membership.rs
@@ -8,11 +8,13 @@ use crate::storage::traits::MemberStore;
 use crate::storage::StorageError;
 
 fn row_to_member(row: sqlx::sqlite::SqliteRow) -> Result<Member, StorageError> {
+    let is_bot_int: i64 = row.try_get("is_bot")?;
     Ok(Member {
         user_id: row.try_get("user_id")?,
         pubkey: row.try_get("pubkey")?,
         display_name: row.try_get("display_name")?,
         avatar_hash: row.try_get("avatar_hash")?,
+        is_bot: is_bot_int != 0,
         joined_at: row.try_get::<DateTime<Utc>, _>("joined_at")?,
     })
 }
@@ -43,7 +45,7 @@ impl MemberStore for SqliteStorage {
             .await?;
 
         let row = sqlx::query(
-            "SELECT m.user_id, u.pubkey, u.display_name, u.avatar_hash, m.joined_at
+            "SELECT m.user_id, u.pubkey, u.display_name, u.avatar_hash, u.is_bot, m.joined_at
              FROM members m
              INNER JOIN users u ON u.id = m.user_id
              WHERE m.user_id = ?",
@@ -80,7 +82,7 @@ impl MemberStore for SqliteStorage {
 
     async fn list_members(&self) -> Result<Vec<Member>, StorageError> {
         let rows = sqlx::query(
-            "SELECT m.user_id, u.pubkey, u.display_name, u.avatar_hash, m.joined_at
+            "SELECT m.user_id, u.pubkey, u.display_name, u.avatar_hash, u.is_bot, m.joined_at
              FROM members m
              INNER JOIN users u ON u.id = m.user_id
              ORDER BY m.joined_at ASC",
@@ -93,7 +95,7 @@ impl MemberStore for SqliteStorage {
 
     async fn get_member_by_pubkey(&self, pubkey: &str) -> Result<Option<Member>, StorageError> {
         let row = sqlx::query(
-            "SELECT m.user_id, u.pubkey, u.display_name, u.avatar_hash, m.joined_at
+            "SELECT m.user_id, u.pubkey, u.display_name, u.avatar_hash, u.is_bot, m.joined_at
              FROM members m
              INNER JOIN users u ON u.id = m.user_id
              WHERE u.pubkey = ?",
@@ -220,8 +222,8 @@ mod tests {
     #[tokio::test]
     async fn member_ban_and_allowlist_crud() {
         let storage = SqliteStorage::in_memory().await.unwrap();
-        let owner = storage.create_user("pk-owner", None).await.unwrap();
-        let member = storage.create_user("pk-member", None).await.unwrap();
+        let owner = storage.create_user("pk-owner", None, false).await.unwrap();
+        let member = storage.create_user("pk-member", None, false).await.unwrap();
 
         let added = storage.add_member(&member.id).await.unwrap();
         assert_eq!(added.pubkey, "pk-member");

--- a/server/src/storage/sqlite/messages.rs
+++ b/server/src/storage/sqlite/messages.rs
@@ -183,7 +183,7 @@ mod tests {
 
     async fn setup() -> (SqliteStorage, String, String) {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let u = s.create_user("pk", None).await.unwrap();
+        let u = s.create_user("pk", None, false).await.unwrap();
         let c = s.create_channel("general", None, 0).await.unwrap();
         (s, u.id, c.id)
     }

--- a/server/src/storage/sqlite/mod.rs
+++ b/server/src/storage/sqlite/mod.rs
@@ -1,4 +1,5 @@
 mod attachments;
+mod bots;
 mod channels;
 mod invites;
 mod media;

--- a/server/src/storage/sqlite/reactions.rs
+++ b/server/src/storage/sqlite/reactions.rs
@@ -161,8 +161,8 @@ mod tests {
 
     async fn setup() -> (SqliteStorage, String, String, String) {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let u1 = s.create_user("pk1", Some("Alice")).await.unwrap();
-        let u2 = s.create_user("pk2", Some("Bob")).await.unwrap();
+        let u1 = s.create_user("pk1", Some("Alice"), false).await.unwrap();
+        let u2 = s.create_user("pk2", Some("Bob"), false).await.unwrap();
         let c = s.create_channel("general", None, 0).await.unwrap();
         let m = s.create_message(&c.id, &u1.id, "hello", None).await.unwrap();
         (s, u1.id, u2.id, m.id)

--- a/server/src/storage/sqlite/roles.rs
+++ b/server/src/storage/sqlite/roles.rs
@@ -339,7 +339,7 @@ mod tests {
     #[tokio::test]
     async fn member_role_assignment() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let user = s.create_user("pk-role", None).await.unwrap();
+        let user = s.create_user("pk-role", None, false).await.unwrap();
 
         let roles = s.list_roles().await.unwrap();
         let everyone = roles.into_iter().find(|r| r.id == "everyone").unwrap();

--- a/server/src/storage/sqlite/sessions.rs
+++ b/server/src/storage/sqlite/sessions.rs
@@ -9,9 +9,11 @@ use crate::storage::traits::SessionStore;
 use crate::storage::StorageError;
 
 fn row_to_session(row: sqlx::sqlite::SqliteRow) -> Result<Session, StorageError> {
+    let is_read_only_int: i64 = row.try_get("is_read_only")?;
     Ok(Session {
         token: row.try_get("token")?,
         user_id: row.try_get("user_id")?,
+        is_read_only: is_read_only_int != 0,
         created_at: row.try_get::<DateTime<Utc>, _>("created_at")?,
         expires_at: row.try_get::<DateTime<Utc>, _>("expires_at")?,
     })
@@ -29,17 +31,21 @@ impl SessionStore for SqliteStorage {
         &self,
         user_id: &str,
         duration: Duration,
+        is_read_only: bool,
     ) -> Result<Session, StorageError> {
         let token = random_token();
         let expires_at: DateTime<Utc> = Utc::now()
             + ChronoDuration::from_std(duration)
                 .map_err(|e| StorageError::Internal(e.to_string()))?;
-        sqlx::query("INSERT INTO sessions (token, user_id, expires_at) VALUES (?, ?, ?)")
-            .bind(&token)
-            .bind(user_id)
-            .bind(expires_at)
-            .execute(self.pool())
-            .await?;
+        sqlx::query(
+            "INSERT INTO sessions (token, user_id, expires_at, is_read_only) VALUES (?, ?, ?, ?)",
+        )
+        .bind(&token)
+        .bind(user_id)
+        .bind(expires_at)
+        .bind(is_read_only as i64)
+        .execute(self.pool())
+        .await?;
         self.get_session(&token)
             .await?
             .ok_or(StorageError::NotFound)
@@ -82,12 +88,13 @@ mod tests {
     #[tokio::test]
     async fn session_create_get_expire() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let u = s.create_user("pk", None).await.unwrap();
+        let u = s.create_user("pk", None, false).await.unwrap();
         let sess = s
-            .create_session(&u.id, Duration::from_secs(3600))
+            .create_session(&u.id, Duration::from_secs(3600), false)
             .await
             .unwrap();
         assert_eq!(sess.user_id, u.id);
+        assert!(!sess.is_read_only);
         assert!(sess.expires_at > Utc::now());
 
         let got = s.get_session(&sess.token).await.unwrap().unwrap();
@@ -95,25 +102,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_only_session_flag_is_stored() {
+        let s = SqliteStorage::in_memory().await.unwrap();
+        let u = s.create_user("pk-bot", None, true).await.unwrap();
+        let sess = s
+            .create_session(&u.id, Duration::from_secs(3600), true)
+            .await
+            .unwrap();
+        assert!(sess.is_read_only);
+    }
+
+    #[tokio::test]
     async fn delete_expired_sessions_only_removes_expired() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let u = s.create_user("pk", None).await.unwrap();
+        let u = s.create_user("pk", None, false).await.unwrap();
 
         let live = s
-            .create_session(&u.id, Duration::from_secs(3600))
+            .create_session(&u.id, Duration::from_secs(3600), false)
             .await
             .unwrap();
 
         // Insert an already-expired row directly to avoid needing a clock.
         let expired_token = ulid::Ulid::new().to_string();
         let past = Utc::now() - ChronoDuration::hours(1);
-        sqlx::query("INSERT INTO sessions (token, user_id, expires_at) VALUES (?, ?, ?)")
-            .bind(&expired_token)
-            .bind(&u.id)
-            .bind(past)
-            .execute(s.pool())
-            .await
-            .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions (token, user_id, expires_at, is_read_only) VALUES (?, ?, ?, 0)",
+        )
+        .bind(&expired_token)
+        .bind(&u.id)
+        .bind(past)
+        .execute(s.pool())
+        .await
+        .unwrap();
 
         let removed = s.delete_expired_sessions().await.unwrap();
         assert_eq!(removed, 1);

--- a/server/src/storage/sqlite/threads.rs
+++ b/server/src/storage/sqlite/threads.rs
@@ -173,7 +173,7 @@ mod tests {
 
     async fn setup() -> (SqliteStorage, String, String, String) {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let u = s.create_user("pk", None).await.unwrap();
+        let u = s.create_user("pk", None, false).await.unwrap();
         let c = s.create_channel("general", None, 0).await.unwrap();
         let m = s.create_message(&c.id, &u.id, "root", None).await.unwrap();
         (s, u.id, c.id, m.id)

--- a/server/src/storage/sqlite/users.rs
+++ b/server/src/storage/sqlite/users.rs
@@ -8,11 +8,13 @@ use crate::storage::traits::UserStore;
 use crate::storage::StorageError;
 
 fn row_to_user(row: sqlx::sqlite::SqliteRow) -> Result<User, StorageError> {
+    let is_bot_int: i64 = row.try_get("is_bot")?;
     Ok(User {
         id: row.try_get("id")?,
         pubkey: row.try_get("pubkey")?,
         display_name: row.try_get("display_name")?,
         avatar_hash: row.try_get("avatar_hash")?,
+        is_bot: is_bot_int != 0,
         created_at: row.try_get::<DateTime<Utc>, _>("created_at")?,
         updated_at: row.try_get::<DateTime<Utc>, _>("updated_at")?,
     })
@@ -24,14 +26,18 @@ impl UserStore for SqliteStorage {
         &self,
         pubkey: &str,
         display_name: Option<&str>,
+        is_bot: bool,
     ) -> Result<User, StorageError> {
         let id = self.new_id();
-        sqlx::query("INSERT INTO users (id, pubkey, display_name) VALUES (?, ?, ?)")
-            .bind(&id)
-            .bind(pubkey)
-            .bind(display_name)
-            .execute(self.pool())
-            .await?;
+        sqlx::query(
+            "INSERT INTO users (id, pubkey, display_name, is_bot) VALUES (?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(pubkey)
+        .bind(display_name)
+        .bind(is_bot as i64)
+        .execute(self.pool())
+        .await?;
         self.get_user_by_id(&id)
             .await?
             .ok_or(StorageError::NotFound)
@@ -106,9 +112,10 @@ mod tests {
     #[tokio::test]
     async fn user_crud() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        let u = s.create_user("pk1", Some("alice")).await.unwrap();
+        let u = s.create_user("pk1", Some("alice"), false).await.unwrap();
         assert_eq!(u.pubkey, "pk1");
         assert_eq!(u.display_name.as_deref(), Some("alice"));
+        assert!(!u.is_bot);
 
         let by_id = s.get_user_by_id(&u.id).await.unwrap().unwrap();
         assert_eq!(by_id, u);
@@ -128,10 +135,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bot_user_is_flagged() {
+        let s = SqliteStorage::in_memory().await.unwrap();
+        let bot = s.create_user("pk-bot", None, true).await.unwrap();
+        assert!(bot.is_bot);
+    }
+
+    #[tokio::test]
     async fn duplicate_pubkey_is_conflict() {
         let s = SqliteStorage::in_memory().await.unwrap();
-        s.create_user("dup", None).await.unwrap();
-        let err = s.create_user("dup", None).await.unwrap_err();
+        s.create_user("dup", None, false).await.unwrap();
+        let err = s.create_user("dup", None, false).await.unwrap_err();
         assert!(matches!(err, StorageError::Conflict(_)));
     }
 }

--- a/server/src/storage/traits.rs
+++ b/server/src/storage/traits.rs
@@ -3,8 +3,9 @@ use chrono::{DateTime, Utc};
 use std::time::Duration;
 
 use super::models::{
-    AllowlistEntry, Attachment, Ban, Channel, ChannelPermissionOverride, Invite, Member,
-    MemberRole, Message, Reaction, ReactionCount, Role, Session, Thread, ThreadSummary, User,
+    AllowlistEntry, Attachment, Ban, BotApproval, Channel, ChannelPermissionOverride, Invite,
+    Member, MemberRole, Message, Reaction, ReactionCount, Role, Session, Thread, ThreadSummary,
+    User,
 };
 use super::StorageError;
 
@@ -14,6 +15,7 @@ pub trait UserStore: Send + Sync {
         &self,
         pubkey: &str,
         display_name: Option<&str>,
+        is_bot: bool,
     ) -> Result<User, StorageError>;
     async fn get_user_by_id(&self, id: &str) -> Result<Option<User>, StorageError>;
     async fn get_user_by_pubkey(&self, pubkey: &str) -> Result<Option<User>, StorageError>;
@@ -85,6 +87,7 @@ pub trait SessionStore: Send + Sync {
         &self,
         user_id: &str,
         duration: Duration,
+        is_read_only: bool,
     ) -> Result<Session, StorageError>;
     async fn get_session(&self, token: &str) -> Result<Option<Session>, StorageError>;
     async fn delete_session(&self, token: &str) -> Result<(), StorageError>;
@@ -288,6 +291,21 @@ pub trait ThreadStore: Send + Sync {
     async fn update_thread_last_read(&self, thread_id: &str, user_id: &str) -> Result<(), StorageError>;
 }
 
+#[async_trait]
+pub trait BotStore: Send + Sync {
+    async fn upsert_bot_pending(&self, pubkey: &str) -> Result<BotApproval, StorageError>;
+    async fn approve_bot(
+        &self,
+        pubkey: &str,
+        approved_by: &str,
+        note: Option<&str>,
+    ) -> Result<BotApproval, StorageError>;
+    async fn revoke_bot(&self, pubkey: &str) -> Result<BotApproval, StorageError>;
+    async fn get_bot_approval(&self, pubkey: &str) -> Result<Option<BotApproval>, StorageError>;
+    async fn list_pending_bots(&self) -> Result<Vec<BotApproval>, StorageError>;
+    async fn is_bot_approved(&self, pubkey: &str) -> Result<bool, StorageError>;
+}
+
 pub struct CreateAttachmentParams<'a> {
     pub channel_id: &'a str,
     pub uploader_id: &'a str,
@@ -311,6 +329,7 @@ pub trait Storage:
     + AttachmentStore
     + ReactionStore
     + ThreadStore
+    + BotStore
 {
 }
 
@@ -326,5 +345,6 @@ impl<T> Storage for T where
         + AttachmentStore
         + ReactionStore
         + ThreadStore
+        + BotStore
 {
 }

--- a/shared/src/auth.rs
+++ b/shared/src/auth.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChallengeRequest {
     pub pubkey: String,
+    #[serde(default)]
+    pub is_bot: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -21,6 +23,8 @@ pub struct VerifyResponse {
     pub token: String,
     pub user_id: String,
     pub expires_at: String,
+    #[serde(default)]
+    pub is_read_only: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct ServerInfo {
     pub name: String,
     pub description: Option<String>,
+    pub membership_mode: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tools/test-setup/src/db.rs
+++ b/tools/test-setup/src/db.rs
@@ -51,19 +51,17 @@ fn seed_one(root: &Path, cfg: &seed::ServerConfig, users: &[User]) -> Result<()>
         )?;
     }
 
-    // Insert bot users and their approvals.
+    // Insert bot users as pending (no approved_at) so the approval flow can be tested.
     for bot_def in cfg.bots {
         let bot = User::find(users, bot_def.name);
-        let approver = User::find(users, bot_def.approved_by);
         conn.execute(
             "INSERT OR IGNORE INTO users (id, pubkey, display_name, is_bot, created_at, updated_at) \
              VALUES (?1, ?2, ?3, 1, ?4, ?5)",
             rusqlite::params![bot.user_id, bot.pubkey, bot.name, ts, ts],
         )?;
         conn.execute(
-            "INSERT OR IGNORE INTO bot_approvals (pubkey, approved_by, approved_at) \
-             VALUES (?1, ?2, ?3)",
-            rusqlite::params![bot.pubkey, approver.user_id, ts],
+            "INSERT OR IGNORE INTO bot_approvals (pubkey) VALUES (?1)",
+            rusqlite::params![bot.pubkey],
         )?;
     }
 

--- a/tools/test-setup/src/db.rs
+++ b/tools/test-setup/src/db.rs
@@ -45,9 +45,25 @@ fn seed_one(root: &Path, cfg: &seed::ServerConfig, users: &[User]) -> Result<()>
     for user_def in cfg.users {
         let user = User::find(users, user_def.name);
         conn.execute(
-            "INSERT OR IGNORE INTO users (id, pubkey, display_name, created_at, updated_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT OR IGNORE INTO users (id, pubkey, display_name, is_bot, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, 0, ?4, ?5)",
             rusqlite::params![user.user_id, user.pubkey, user_def.display_name, ts, ts],
+        )?;
+    }
+
+    // Insert bot users and their approvals.
+    for bot_def in cfg.bots {
+        let bot = User::find(users, bot_def.name);
+        let approver = User::find(users, bot_def.approved_by);
+        conn.execute(
+            "INSERT OR IGNORE INTO users (id, pubkey, display_name, is_bot, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, 1, ?4, ?5)",
+            rusqlite::params![bot.user_id, bot.pubkey, bot.name, ts, ts],
+        )?;
+        conn.execute(
+            "INSERT OR IGNORE INTO bot_approvals (pubkey, approved_by, approved_at) \
+             VALUES (?1, ?2, ?3)",
+            rusqlite::params![bot.pubkey, approver.user_id, ts],
         )?;
     }
 

--- a/tools/test-setup/src/seed/mod.rs
+++ b/tools/test-setup/src/seed/mod.rs
@@ -137,7 +137,6 @@ pub struct AllowlistEntry {
 
 pub struct BotSeed {
     pub name: &'static str,
-    pub approved_by: &'static str,
 }
 
 pub struct ServerConfig {

--- a/tools/test-setup/src/seed/mod.rs
+++ b/tools/test-setup/src/seed/mod.rs
@@ -41,6 +41,8 @@ pub fn all_users() -> Vec<User> {
         User::new("bob", [0x02; 32]),
         User::new("charlie", [0x03; 32]),
         User::new("dave", [0x04; 32]),
+        User::new("bot-alpha", [0x10; 32]),
+        User::new("bot-beta", [0x11; 32]),
     ]
 }
 
@@ -133,6 +135,11 @@ pub struct AllowlistEntry {
     pub added_by: &'static str,
 }
 
+pub struct BotSeed {
+    pub name: &'static str,
+    pub approved_by: &'static str,
+}
+
 pub struct ServerConfig {
     pub db_name: &'static str,
     pub display_name: &'static str,
@@ -144,6 +151,7 @@ pub struct ServerConfig {
     pub reactions: &'static [MessageReactions],
     pub invites: &'static [InviteSeed],
     pub allowlist: &'static [AllowlistEntry],
+    pub bots: &'static [BotSeed],
 }
 
 static ALL_SERVERS: [&ServerConfig; 3] = [&servers::OPEN, &servers::PRIVATE, &servers::STRICT];
@@ -158,9 +166,18 @@ pub fn print_summary(users: &[User]) {
     println!("{}", "=".repeat(60));
     println!("\nTest Accounts (all stored in OS keychain):");
     println!("{}", "-".repeat(60));
-    for user in users {
+    let (bots, humans): (Vec<_>, Vec<_>) = users.iter().partition(|u| u.name.starts_with("bot-"));
+    for user in &humans {
         println!("  {:<10}  {}…", user.name, &user.pubkey[..20]);
     }
+    println!();
+    println!("Bot Accounts:");
+    println!("{}", "-".repeat(60));
+    for bot in &bots {
+        println!("  {:<12}  id: {}  pubkey: {}…", bot.name, bot.user_id, &bot.pubkey[..20]);
+    }
+    println!("  bot-alpha — approved on Open Server (localhost:8081)");
+    println!("  bot-beta  — not registered with any server");
     println!();
     println!("Server Layout:");
     println!("{}", "-".repeat(60));

--- a/tools/test-setup/src/seed/servers.rs
+++ b/tools/test-setup/src/seed/servers.rs
@@ -1,6 +1,6 @@
 use super::{
-    AllowlistEntry, Channel, CustomRole, EmojiReaction, InviteSeed, Message, MessageReactions,
-    ServerConfig, ThreadReply, ThreadSeed, UserConfig,
+    AllowlistEntry, BotSeed, Channel, CustomRole, EmojiReaction, InviteSeed, Message,
+    MessageReactions, ServerConfig, ThreadReply, ThreadSeed, UserConfig,
 };
 use super::perm;
 
@@ -434,6 +434,10 @@ pub static OPEN: ServerConfig = ServerConfig {
     ],
     invites: &[],
     allowlist: &[],
+    bots: &[BotSeed {
+        name: "bot-alpha",
+        approved_by: "alice",
+    }],
 };
 
 pub static PRIVATE: ServerConfig = ServerConfig {
@@ -630,6 +634,7 @@ pub static PRIVATE: ServerConfig = ServerConfig {
         max_uses: 0,
     }],
     allowlist: &[],
+    bots: &[],
 };
 
 pub static STRICT: ServerConfig = ServerConfig {
@@ -754,4 +759,5 @@ pub static STRICT: ServerConfig = ServerConfig {
             added_by: "alice",
         },
     ],
+    bots: &[],
 };

--- a/tools/test-setup/src/seed/servers.rs
+++ b/tools/test-setup/src/seed/servers.rs
@@ -434,10 +434,7 @@ pub static OPEN: ServerConfig = ServerConfig {
     ],
     invites: &[],
     allowlist: &[],
-    bots: &[BotSeed {
-        name: "bot-alpha",
-        approved_by: "alice",
-    }],
+    bots: &[BotSeed { name: "bot-alpha" }],
 };
 
 pub static PRIVATE: ServerConfig = ServerConfig {


### PR DESCRIPTION
Closes #75

## Summary
- Introduces a first-class bot account type using the same Ed25519 challenge-response auth as humans
- The `is_bot` claim is bound into the signed challenge text (appending `|bot`) so it cannot be stripped or swapped
- Unapproved bots land in a pending queue and receive read-only sessions; they cannot send messages until an admin approves them
- Admin endpoints for listing pending bots, approving, and revoking

## Changes
- **Migration 009_bots**: adds `is_bot` to `users`, `bot_approvals` table, `is_read_only` to `sessions`
- **Shared types**: `ChallengeRequest.is_bot`, `VerifyResponse.is_read_only`
- **Storage**: new `BotStore` trait + SQLite implementation; `User`, `Member`, `Session` models extended
- **Auth flow**: challenge text binds `is_bot`; verify handler issues read-only sessions for unapproved bots
- **Admin API**: `GET /api/v1/admin/bots/pending`, `POST /api/v1/admin/bots/:pubkey/approve|revoke`
- **Members API**: `is_bot` included in all member responses
- **Read-only enforcement**: bots with unapproved sessions blocked from `create_message`
- **Client**: BOT badge in member list and message author display; BotApprovalPanel in server settings

## Testing
- All existing tests pass (114 server + 88 client)
- New unit tests: `challenge_store_preserves_is_bot_flag`, `bot_user_is_flagged`, `read_only_session_flag_is_stored`, `bot_approval_lifecycle`, `upsert_bot_pending_is_idempotent`
- `cargo clippy -- -D warnings`: clean
- `pnpm lint`: clean