### PR TITLE
feat: backend security hardening - profile, session, CORS (#91)

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -30,6 +30,7 @@ pub struct ServerIdentity {
 #[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {
     pub bind_address: SocketAddr,
+    pub allowed_origins: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
@@ -111,6 +112,7 @@ impl Default for NetworkConfig {
     fn default() -> Self {
         Self {
             bind_address: "127.0.0.1:8080".parse().expect("valid default addr"),
+            allowed_origins: Vec::new(),
         }
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -18,11 +18,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::http::{header, Method};
+use axum::http::{header, HeaderValue, Method};
 use axum::{extract::State, routing::get, Json, Router};
 use clap::Parser;
 use shared::HealthStatus;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::{info, warn};
 
 use crate::config::{ServerConfig, StorageBackendType};
@@ -45,6 +45,7 @@ pub struct AppState {
 }
 
 pub fn app(state: AppState) -> Router {
+    let cors = cors_layer(&state.config.network.allowed_origins);
     Router::new()
         .route("/health", get(health))
         .nest("/api/v1", channels::router())
@@ -59,15 +60,22 @@ pub fn app(state: AppState) -> Router {
         .nest("/api/v1", threads::router())
         .nest("/api/v1/auth", auth::router())
         .nest("/api/v1/gateway", gateway::router())
-        .layer(cors_layer())
+        .layer(cors)
         .with_state(state)
 }
 
-fn cors_layer() -> CorsLayer {
-    // Tauri WebView requests originate from non-http origins; allow REST calls
-    // in development until we add a stricter per-origin server config.
+fn cors_layer(allowed_origins: &[String]) -> CorsLayer {
+    let origin = if allowed_origins.is_empty() {
+        AllowOrigin::any()
+    } else {
+        let values: Vec<HeaderValue> = allowed_origins
+            .iter()
+            .filter_map(|o| o.parse().ok())
+            .collect();
+        AllowOrigin::list(values)
+    };
     CorsLayer::new()
-        .allow_origin(Any)
+        .allow_origin(origin)
         .allow_methods([
             Method::GET,
             Method::POST,

--- a/server/src/profiles/handlers.rs
+++ b/server/src/profiles/handlers.rs
@@ -5,7 +5,6 @@ use axum_extra::extract::Multipart;
 use serde::{Deserialize, Serialize};
 use shared::gateway::Op;
 
-use crate::auth::middleware::AuthUser;
 use crate::gateway::events::event_json;
 use crate::permissions::MemberUser;
 use crate::profiles::avatar::{process_and_store_avatar, AvatarError};
@@ -84,7 +83,7 @@ pub struct UpdateProfileRequest {
 /// PATCH /profile — update own display name.
 pub(super) async fn update_profile(
     State(state): State<AppState>,
-    auth: AuthUser,
+    auth: MemberUser,
     Json(req): Json<UpdateProfileRequest>,
 ) -> ApiResult<ProfileResponse> {
     let display_name = req
@@ -118,7 +117,7 @@ pub(super) async fn update_profile(
 /// PUT /profile/avatar — upload or replace own avatar.
 pub(super) async fn upload_avatar(
     State(state): State<AppState>,
-    auth: AuthUser,
+    auth: MemberUser,
     mut multipart: Multipart,
 ) -> ApiResult<ProfileResponse> {
     let field = multipart
@@ -157,7 +156,7 @@ pub(super) async fn upload_avatar(
 /// DELETE /profile/avatar — remove own avatar.
 pub(super) async fn delete_avatar(
     State(state): State<AppState>,
-    auth: AuthUser,
+    auth: MemberUser,
 ) -> ApiResult<ProfileResponse> {
     let user = state
         .storage

--- a/server/src/storage/sqlite/sessions.rs
+++ b/server/src/storage/sqlite/sessions.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use rand::RngCore;
 use sqlx::Row;
 use std::time::Duration;
 
@@ -18,9 +19,9 @@ fn row_to_session(row: sqlx::sqlite::SqliteRow) -> Result<Session, StorageError>
 }
 
 fn random_token() -> String {
-    // Use ULID as an opaque random-ish token. Secure token generation will
-    // be revisited by the auth feature.
-    ulid::Ulid::new().to_string()
+    let mut bytes = [0u8; 16];
+    rand::rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
 }
 
 #[async_trait]


### PR DESCRIPTION
Closes #91

## Summary
- Profile and avatar mutation endpoints now require membership (MemberUser extractor) to prevent non-members from consuming storage
- Session tokens upgraded from time-predictable ULIDs to 128-bit CSPRNG hex strings
- `NetworkConfig` gains `allowed_origins: Vec<String>`; when set, the CORS layer restricts allowed origins rather than using `Any`

## Changes
- `server/src/profiles/handlers.rs`: `update_profile`, `upload_avatar`, `delete_avatar` now extract `MemberUser` instead of `AuthUser`
- `server/src/storage/sqlite/sessions.rs`: `random_token()` uses `rand::rng().fill_bytes()` for a 32-char hex token
- `server/src/config.rs`: `NetworkConfig.allowed_origins: Vec<String>` added (default: empty)
- `server/src/main.rs`: `cors_layer()` accepts origins slice; uses `AllowOrigin::list()` when non-empty, `AllowOrigin::any()` otherwise

## Testing
- All 109 server tests pass
- `cargo clippy -- -D warnings`: clean
- Session token tests cover create/get/expire and expired-cleanup paths