### PR TITLE
fix: allow switching servers (#97)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
     refresh,
   } = useIdentity();
   const { currentServerId, servers, addServer, setCurrentServer, initTheme } = useAppStore();
-  const { connect, status } = useServerStore();
+  const { connect, status, address } = useServerStore();
   const joinInvite = useInvitesStore((state) => state.joinInvite);
   const { invite, clearInviteLink } = useInviteLink();
   const [connectLoading, setConnectLoading] = useState(false);
@@ -90,11 +90,12 @@ function App() {
         currentServerId,
         status,
         connectLoading,
+        address,
       })
     ) {
       handleConnect(currentServerId!);
     }
-  }, [currentServerId, hasIdentity, loading, status, connectLoading, handleConnect, isSwitching, shouldAutoConnect]);
+  }, [currentServerId, hasIdentity, loading, status, connectLoading, handleConnect, isSwitching, shouldAutoConnect, address]);
 
   async function handleJoinByInvite(address: string, inviteCode: string) {
     setConnectLoading(true);

--- a/client/src/hooks/useAccountManager.test.ts
+++ b/client/src/hooks/useAccountManager.test.ts
@@ -166,6 +166,7 @@ describe("useAccountManager", () => {
         currentServerId: "http://localhost:8080",
         status: "disconnected",
         connectLoading: false,
+        address: "http://localhost:8080",
       });
 
       expect(canConnect).toBe(false);
@@ -181,6 +182,23 @@ describe("useAccountManager", () => {
         currentServerId: "http://localhost:8080",
         status: "disconnected",
         connectLoading: false,
+        address: "http://localhost:8080",
+      });
+
+      expect(canConnect).toBe(true);
+    });
+
+    it("returns true when currentServerId is different from current address", () => {
+      useAccountManagerStore.setState({ isSwitching: false });
+      const { result } = renderHook(() => useAccountManager());
+
+      const canConnect = result.current.shouldAutoConnect({
+        hasIdentity: true,
+        loading: false,
+        currentServerId: "http://localhost:8081",
+        status: "connected",
+        connectLoading: false,
+        address: "http://localhost:8080",
       });
 
       expect(canConnect).toBe(true);
@@ -195,6 +213,7 @@ describe("useAccountManager", () => {
         currentServerId: null,
         status: "disconnected",
         connectLoading: false,
+        address: "",
       });
 
       expect(canConnect).toBe(false);

--- a/client/src/hooks/useAccountManager.ts
+++ b/client/src/hooks/useAccountManager.ts
@@ -114,13 +114,17 @@ export function useAccountManager() {
       currentServerId: string | null;
       status: string;
       connectLoading: boolean;
+      address: string;
     }) => {
       if (useAccountManagerStore.getState().isSwitching) return false;
+
+      const isDifferentServer = opts.currentServerId && opts.currentServerId !== opts.address;
+
       return (
         opts.hasIdentity &&
         !opts.loading &&
         !!opts.currentServerId &&
-        opts.status === "disconnected" &&
+        (opts.status === "disconnected" || isDifferentServer) &&
         !opts.connectLoading &&
         useAppStore.persist.hasHydrated()
       );

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -156,6 +156,9 @@ export const useServerStore = create<ServerStore>((set, get) => ({
 
   connect: async (address: string) => {
     const normalized = normalizeAddress(address);
+    if (get().address && get().address !== normalized) {
+      get().disconnect();
+    }
     set({ status: "connecting", error: null, address: normalized, serverId: normalized });
 
     try {


### PR DESCRIPTION
Closes #97

## Summary
Fixed a bug where the application would not switch connections when a different server was selected in the sidebar if already connected to a server.

## Changes
- Updated `shouldAutoConnect` in `useAccountManager.ts` to allow connection if the target `currentServerId` differs from the currently connected `address`.
- Updated `useServerStore.connect` to explicitly call `disconnect()` when the address changes, ensuring a clean state and closing the previous gateway connection.
- Updated `App.tsx` to pass the current `address` to `shouldAutoConnect`.
- Added unit tests for the new `shouldAutoConnect` logic.

## Testing
- All existing tests pass.
- New unit test for server-switching connection logic passed.