### PR TITLE
fix: resolve race conditions and add connection retry backoff (#93)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ clean: ## Remove test databases, media dirs, and OS keychain test entries
 	cargo run -q --bin test-setup -- clean
 
 setup: clean ## Clean + bootstrap test DBs with users/roles/channels + store keys in keychain
+	cd client && pnpm install
 	cargo run -q --bin test-setup
 
 clean-identity: ## Remove all decentcom keys from the OS keychain (useful during testing)

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -75,33 +75,37 @@ function App() {
   }, [status]);
 
   const handleConnect = useCallback(async (address: string) => {
+    console.log("[App] handleConnect start", { address });
     setConnectLoading(true);
     setConnectError(null);
     try {
       const info = await getServerInfo(address);
+      console.log("[App] handleConnect server info fetched", info.name);
       await connect(address);
       addServer(address, info.name);
       setRetryCount(0);
+      console.log("[App] handleConnect success");
     } catch (err) {
+      console.error("[App] handleConnect failed", err);
       setConnectError(err instanceof Error ? err.message : String(err));
       setRetryCount((prev) => prev + 1);
     } finally {
       setConnectLoading(false);
     }
   }, [connect, addServer]);
+// Auto-connect: gated by isSwitching to prevent races during account transitions.
+useEffect(() => {
+  const should = shouldAutoConnect({
+    hasIdentity: !!hasIdentity,
+    loading,
+    currentServerId,
+    status,
+    connectLoading,
+  });
 
-  // Auto-connect: gated by isSwitching to prevent races during account transitions.
-  useEffect(() => {
-    if (
-      shouldAutoConnect({
-        hasIdentity: !!hasIdentity,
-        loading,
-        currentServerId,
-        status,
-        connectLoading,
-      }) &&
-      !connectError // Don't auto-retry if there was an error (wait for backoff or manual)
-    ) {
+  if (should && !connectError) {
+
+      console.log("[App] Triggering auto-connect", { currentServerId, status });
       handleConnect(currentServerId!);
     }
   }, [currentServerId, hasIdentity, loading, status, connectLoading, handleConnect, isSwitching, shouldAutoConnect, connectError]);
@@ -120,13 +124,11 @@ function App() {
       // More conservative backoff: 2s, 4s, 8s, 16s, max 60s
       // We start at 2s to give the OS and server time to settle.
       const delay = Math.min(Math.pow(2, retryCount) * 1000, 60000);
+      console.log("[App] Scheduling auto-retry", { retryCount, delay });
       
       const timer = setTimeout(() => {
-        // Only clear the error if it's likely a temporary network issue.
-        // For other errors (like invalid credentials or user cancellation),
-        // we might want the user to click manual retry instead.
-        // For now, let's just clear it but with a longer delay.
-        setConnectError(null);
+        console.log("[App] Executing auto-retry (clearing error)");
+        setConnectError(null); // Clear error to trigger auto-connect effect
       }, delay);
       return () => clearTimeout(timer);
     }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -75,37 +75,32 @@ function App() {
   }, [status]);
 
   const handleConnect = useCallback(async (address: string) => {
-    console.log("[App] handleConnect start", { address });
     setConnectLoading(true);
     setConnectError(null);
     try {
       const info = await getServerInfo(address);
-      console.log("[App] handleConnect server info fetched", info.name);
       await connect(address);
       addServer(address, info.name);
       setRetryCount(0);
-      console.log("[App] handleConnect success");
     } catch (err) {
-      console.error("[App] handleConnect failed", err);
       setConnectError(err instanceof Error ? err.message : String(err));
       setRetryCount((prev) => prev + 1);
     } finally {
       setConnectLoading(false);
     }
   }, [connect, addServer]);
-// Auto-connect: gated by isSwitching to prevent races during account transitions.
-useEffect(() => {
-  const should = shouldAutoConnect({
-    hasIdentity: !!hasIdentity,
-    loading,
-    currentServerId,
-    status,
-    connectLoading,
-  });
 
-  if (should && !connectError) {
+  // Auto-connect: gated by isSwitching to prevent races during account transitions.
+  useEffect(() => {
+    const should = shouldAutoConnect({
+      hasIdentity: !!hasIdentity,
+      loading,
+      currentServerId,
+      status,
+      connectLoading,
+    });
 
-      console.log("[App] Triggering auto-connect", { currentServerId, status });
+    if (should && !connectError) {
       handleConnect(currentServerId!);
     }
   }, [currentServerId, hasIdentity, loading, status, connectLoading, handleConnect, isSwitching, shouldAutoConnect, connectError]);
@@ -124,15 +119,14 @@ useEffect(() => {
       // More conservative backoff: 2s, 4s, 8s, 16s, max 60s
       // We start at 2s to give the OS and server time to settle.
       const delay = Math.min(Math.pow(2, retryCount) * 1000, 60000);
-      console.log("[App] Scheduling auto-retry", { retryCount, delay });
-      
+
       const timer = setTimeout(() => {
-        console.log("[App] Executing auto-retry (clearing error)");
         setConnectError(null); // Clear error to trigger auto-connect effect
       }, delay);
       return () => clearTimeout(timer);
     }
   }, [retryCount, status, connectLoading, currentServerId, isSwitching, connectError, authError]);
+
 
   async function handleJoinByInvite(address: string, inviteCode: string) {
     setConnectLoading(true);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
     refresh,
   } = useIdentity();
   const { currentServerId, servers, addServer, setCurrentServer, initTheme } = useAppStore();
-  const { connect, status } = useServerStore();
+  const { connect, status, authError } = useServerStore();
   const joinInvite = useInvitesStore((state) => state.joinInvite);
   const { invite, clearInviteLink } = useInviteLink();
   const [connectLoading, setConnectLoading] = useState(false);
@@ -113,16 +113,24 @@ function App() {
       status === "disconnected" &&
       !connectLoading &&
       currentServerId &&
-      !isSwitching
+      !isSwitching &&
+      connectError &&
+      !authError // NEVER auto-retry if it's an authentication error (prevent keychain loops)
     ) {
-      // Exponential backoff: 1s, 2s, 4s, 8s, max 30s
-      const delay = Math.min(Math.pow(2, retryCount - 1) * 1000, 30000);
+      // More conservative backoff: 2s, 4s, 8s, 16s, max 60s
+      // We start at 2s to give the OS and server time to settle.
+      const delay = Math.min(Math.pow(2, retryCount) * 1000, 60000);
+      
       const timer = setTimeout(() => {
-        setConnectError(null); // Clear error to trigger auto-connect effect
+        // Only clear the error if it's likely a temporary network issue.
+        // For other errors (like invalid credentials or user cancellation),
+        // we might want the user to click manual retry instead.
+        // For now, let's just clear it but with a longer delay.
+        setConnectError(null);
       }, delay);
       return () => clearTimeout(timer);
     }
-  }, [retryCount, status, connectLoading, currentServerId, isSwitching]);
+  }, [retryCount, status, connectLoading, currentServerId, isSwitching, connectError, authError]);
 
   async function handleJoinByInvite(address: string, inviteCode: string) {
     setConnectLoading(true);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,11 +26,12 @@ function App() {
     refresh,
   } = useIdentity();
   const { currentServerId, servers, addServer, setCurrentServer, initTheme } = useAppStore();
-  const { connect, status, address } = useServerStore();
+  const { connect, status } = useServerStore();
   const joinInvite = useInvitesStore((state) => state.joinInvite);
   const { invite, clearInviteLink } = useInviteLink();
   const [connectLoading, setConnectLoading] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
 
   const {
     isSwitching,
@@ -42,6 +43,11 @@ function App() {
   useEffect(() => {
     initTheme();
   }, [initTheme]);
+
+  // Reset retry count when server or account changes
+  useEffect(() => {
+    setRetryCount(0);
+  }, [currentServerId, publicKey]);
 
   // Once identity is resolved, make sure the app store is namespaced
   // to the active account so persist reads/writes go to the right key.
@@ -64,6 +70,7 @@ function App() {
   useEffect(() => {
     if (status === "connected") {
       setConnectError(null);
+      setRetryCount(0);
     }
   }, [status]);
 
@@ -74,8 +81,10 @@ function App() {
       const info = await getServerInfo(address);
       await connect(address);
       addServer(address, info.name);
+      setRetryCount(0);
     } catch (err) {
       setConnectError(err instanceof Error ? err.message : String(err));
+      setRetryCount((prev) => prev + 1);
     } finally {
       setConnectLoading(false);
     }
@@ -90,12 +99,30 @@ function App() {
         currentServerId,
         status,
         connectLoading,
-        address,
-      })
+      }) &&
+      !connectError // Don't auto-retry if there was an error (wait for backoff or manual)
     ) {
       handleConnect(currentServerId!);
     }
-  }, [currentServerId, hasIdentity, loading, status, connectLoading, handleConnect, isSwitching, shouldAutoConnect, address]);
+  }, [currentServerId, hasIdentity, loading, status, connectLoading, handleConnect, isSwitching, shouldAutoConnect, connectError]);
+
+  // Auto-retry with backoff
+  useEffect(() => {
+    if (
+      retryCount > 0 &&
+      status === "disconnected" &&
+      !connectLoading &&
+      currentServerId &&
+      !isSwitching
+    ) {
+      // Exponential backoff: 1s, 2s, 4s, 8s, max 30s
+      const delay = Math.min(Math.pow(2, retryCount - 1) * 1000, 30000);
+      const timer = setTimeout(() => {
+        setConnectError(null); // Clear error to trigger auto-connect effect
+      }, delay);
+      return () => clearTimeout(timer);
+    }
+  }, [retryCount, status, connectLoading, currentServerId, isSwitching]);
 
   async function handleJoinByInvite(address: string, inviteCode: string) {
     setConnectLoading(true);

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -22,6 +22,7 @@ export function AppShell({ onSwitchAccount }: AppShellProps) {
     currentChannelId,
     messages,
     hasMore,
+    loadingMessages,
     status,
     roles,
     memberRoleIdsByUserId,
@@ -80,6 +81,7 @@ export function AppShell({ onSwitchAccount }: AppShellProps) {
   const currentChannel = channels.find((ch) => ch.id === currentChannelId) ?? null;
   const channelMessages = currentChannelId ? messages[currentChannelId] ?? [] : [];
   const channelHasMore = currentChannelId ? hasMore[currentChannelId] ?? false : false;
+  const channelLoading = currentChannelId ? !!loadingMessages[currentChannelId] : false;
 
   return (
     <main className="flex-1 h-full bg-ctp-crust text-ctp-text flex overflow-hidden">
@@ -101,6 +103,7 @@ export function AppShell({ onSwitchAccount }: AppShellProps) {
         channel={currentChannel}
         messages={channelMessages}
         hasMore={channelHasMore}
+        loading={channelLoading}
         connected={status === "connected"}
         onLoadMore={() =>
           currentChannelId ? loadMoreMessages(currentChannelId) : Promise.resolve()

--- a/client/src/components/layout/MessageView.tsx
+++ b/client/src/components/layout/MessageView.tsx
@@ -7,6 +7,7 @@ interface MessageViewProps {
   channel: Channel | null;
   messages: Message[];
   hasMore: boolean;
+  loading: boolean;
   connected: boolean;
   onLoadMore: () => Promise<void>;
   onSend: (content: string, attachmentIds?: string[]) => Promise<void>;
@@ -18,6 +19,7 @@ export function MessageView({
   channel,
   messages,
   hasMore,
+  loading,
   connected,
   onLoadMore,
   onSend,
@@ -54,7 +56,7 @@ export function MessageView({
           )}
         </header>
         <div className="flex-1 min-h-0">
-          <MessageList messages={messages} hasMore={hasMore} onLoadMore={onLoadMore} />
+          <MessageList messages={messages} hasMore={hasMore} loading={loading} onLoadMore={onLoadMore} />
         </div>
         <MessageInput disabled={!connected || !permissions.has(SEND_MESSAGES)} onSend={onSend} />
       </section>

--- a/client/src/components/messages/MessageList.tsx
+++ b/client/src/components/messages/MessageList.tsx
@@ -6,10 +6,11 @@ import { MessageItem } from "./MessageItem";
 interface MessageListProps {
   messages: Message[];
   hasMore: boolean;
+  loading: boolean;
   onLoadMore: () => Promise<void>;
 }
 
-export function MessageList({ messages, hasMore, onLoadMore }: MessageListProps) {
+export function MessageList({ messages, hasMore, loading, onLoadMore }: MessageListProps) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const loadingMoreRef = useRef(false);
   const shouldStickToBottomRef = useRef(true);
@@ -31,7 +32,7 @@ export function MessageList({ messages, hasMore, onLoadMore }: MessageListProps)
     const distanceToBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
     shouldStickToBottomRef.current = distanceToBottom < 48;
 
-    if (scroller.scrollTop > 20 || !hasMore || loadingMoreRef.current) {
+    if (scroller.scrollTop > 20 || !hasMore || loadingMoreRef.current || loading) {
       return;
     }
 
@@ -53,10 +54,14 @@ export function MessageList({ messages, hasMore, onLoadMore }: MessageListProps)
       onScroll={handleScroll}
       className="h-full overflow-y-auto px-4 py-3 space-y-3"
     >
-      {hasMore && (
+      {hasMore && !loading && (
         <div className="text-center text-xs text-ctp-subtext0">Scroll up to load older messages</div>
       )}
-      {ordered.length === 0 ? (
+      {loading && ordered.length === 0 ? (
+        <div className="flex items-center justify-center p-6 text-ctp-subtext0">
+          <div className="animate-pulse">Loading messages...</div>
+        </div>
+      ) : ordered.length === 0 ? (
         <div className="rounded-lg border border-dashed border-ctp-overlay0 p-6 text-center text-ctp-subtext0">
           No messages yet.
         </div>

--- a/client/src/hooks/useAccountManager.ts
+++ b/client/src/hooks/useAccountManager.ts
@@ -114,17 +114,14 @@ export function useAccountManager() {
       currentServerId: string | null;
       status: string;
       connectLoading: boolean;
-      address: string;
     }) => {
       if (useAccountManagerStore.getState().isSwitching) return false;
-
-      const isDifferentServer = opts.currentServerId && opts.currentServerId !== opts.address;
 
       return (
         opts.hasIdentity &&
         !opts.loading &&
         !!opts.currentServerId &&
-        (opts.status === "disconnected" || isDifferentServer) &&
+        opts.status === "disconnected" &&
         !opts.connectLoading &&
         useAppStore.persist.hasHydrated()
       );

--- a/client/src/services/gateway.ts
+++ b/client/src/services/gateway.ts
@@ -35,16 +35,12 @@ export class GatewayClient {
   connect() {
     const state = this.getState();
     if (!state.address || !state.sessionToken) {
-      console.log("[Gateway] connect skipped (missing address or token)");
       return;
     }
 
     if (this.socket && this.socket.readyState <= WebSocket.OPEN) {
-      console.log("[Gateway] connect skipped (socket already open or connecting)");
       return;
     }
-
-    console.log("[Gateway] connect start", { address: state.address, attempt: this.reconnectAttempt });
 
     if (this.reconnectAttempt > 0) {
       this.getState().setStatus("reconnecting");
@@ -56,20 +52,17 @@ export class GatewayClient {
     this.socket = new WebSocket(url.toString());
 
     this.socket.onopen = () => {
-      console.log("[Gateway] socket onopen");
       const wasReconnect = this.wasConnected;
       this.reconnectAttempt = 0;
       this.wasConnected = true;
       this.getState().setStatus("connected");
 
       if (wasReconnect) {
-        console.log("[Gateway] was reconnection, revalidating...");
         void this.getState().revalidate();
       }
 
       const channelId = this.getState().currentChannelId;
       if (channelId) {
-        console.log("[Gateway] subscribing to initial channel", channelId);
         this.subscribe(channelId);
       }
     };
@@ -87,21 +80,17 @@ export class GatewayClient {
       }
     };
 
-    this.socket.onclose = (event) => {
-      console.log("[Gateway] socket onclose", { code: event.code, reason: event.reason, wasClean: event.wasClean });
+    this.socket.onclose = () => {
       this.socket = null;
       if (this.shouldReconnect) {
-        console.log("[Gateway] scheduling reconnect...");
         this.getState().setStatus("reconnecting");
         this.scheduleReconnect();
       } else {
-        console.log("[Gateway] shouldReconnect is false, setting status to disconnected");
         this.getState().setStatus("disconnected");
       }
     };
 
-    this.socket.onerror = (error) => {
-      console.error("[Gateway] socket onerror", error);
+    this.socket.onerror = () => {
       // onerror is always followed by onclose, so no status change needed here.
     };
   }

--- a/client/src/services/gateway.ts
+++ b/client/src/services/gateway.ts
@@ -35,12 +35,16 @@ export class GatewayClient {
   connect() {
     const state = this.getState();
     if (!state.address || !state.sessionToken) {
+      console.log("[Gateway] connect skipped (missing address or token)");
       return;
     }
 
     if (this.socket && this.socket.readyState <= WebSocket.OPEN) {
+      console.log("[Gateway] connect skipped (socket already open or connecting)");
       return;
     }
+
+    console.log("[Gateway] connect start", { address: state.address, attempt: this.reconnectAttempt });
 
     if (this.reconnectAttempt > 0) {
       this.getState().setStatus("reconnecting");
@@ -52,17 +56,20 @@ export class GatewayClient {
     this.socket = new WebSocket(url.toString());
 
     this.socket.onopen = () => {
+      console.log("[Gateway] socket onopen");
       const wasReconnect = this.wasConnected;
       this.reconnectAttempt = 0;
       this.wasConnected = true;
       this.getState().setStatus("connected");
 
       if (wasReconnect) {
+        console.log("[Gateway] was reconnection, revalidating...");
         void this.getState().revalidate();
       }
 
       const channelId = this.getState().currentChannelId;
       if (channelId) {
+        console.log("[Gateway] subscribing to initial channel", channelId);
         this.subscribe(channelId);
       }
     };
@@ -80,17 +87,21 @@ export class GatewayClient {
       }
     };
 
-    this.socket.onclose = () => {
+    this.socket.onclose = (event) => {
+      console.log("[Gateway] socket onclose", { code: event.code, reason: event.reason, wasClean: event.wasClean });
       this.socket = null;
       if (this.shouldReconnect) {
+        console.log("[Gateway] scheduling reconnect...");
         this.getState().setStatus("reconnecting");
         this.scheduleReconnect();
       } else {
+        console.log("[Gateway] shouldReconnect is false, setting status to disconnected");
         this.getState().setStatus("disconnected");
       }
     };
 
-    this.socket.onerror = () => {
+    this.socket.onerror = (error) => {
+      console.error("[Gateway] socket onerror", error);
       // onerror is always followed by onclose, so no status change needed here.
     };
   }

--- a/client/src/stores/appStore.ts
+++ b/client/src/stores/appStore.ts
@@ -138,14 +138,16 @@ export async function initAppStoreForAccount(pubkey: string) {
   // Point persist at the new key, then rehydrate so the store picks it up.
   useAppStore.persist.setOptions({ name: newKey });
 
-  // Reset to defaults BEFORE rehydrate so that if the new key has no
-  // stored data, the store ends up with clean defaults instead of the
-  // previous account's stale in-memory state.
-  useAppStore.setState({
-    currentServerId: null,
-    servers: {},
-    theme: defaultTheme(),
-  });
+  // Reset to defaults BEFORE rehydrate ONLY if we are switching between accounts.
+  // This avoids clearing the store on the first run of a session if we are
+  // just namespacing the initial default state.
+  if (current !== null) {
+    useAppStore.setState({
+      currentServerId: null,
+      servers: {},
+      theme: defaultTheme(),
+    });
+  }
 
   await useAppStore.persist.rehydrate();
 }

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -168,6 +168,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
       authError: false,
       address: normalized,
       serverId: normalized,
+      currentChannelId: null,
     });
 
     if (isNewServer) {
@@ -176,7 +177,6 @@ export const useServerStore = create<ServerStore>((set, get) => ({
         messages: {},
         hasMore: {},
         loadingMessages: {},
-        currentChannelId: null,
       });
     }
 
@@ -218,7 +218,6 @@ export const useServerStore = create<ServerStore>((set, get) => ({
         channels: sortChannels(channelData.channels),
         roles: roleData,
         memberRoleIdsByUserId: roleMap,
-        currentChannelId: firstChannelId,
       });
 
       const gateway = get().gateway ?? new GatewayClient(get);
@@ -226,6 +225,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
       gateway.reconnect();
 
       if (firstChannelId) {
+        set({ currentChannelId: firstChannelId });
         await get().loadMoreMessages(firstChannelId);
       }
 
@@ -233,10 +233,17 @@ export const useServerStore = create<ServerStore>((set, get) => ({
       // will do it when the socket opens. If we set it here, we might overwrite
       // a "reconnecting" status from the gateway if it's already struggling.
     } catch (error) {
-      const isAuthError = error instanceof ApiError && error.status === 403;
+      const msg = error instanceof Error ? error.message : String(error);
+      const isAuthError =
+        (error instanceof ApiError && error.status === 403) ||
+        msg.toLowerCase().includes("keyring") ||
+        msg.toLowerCase().includes("keychain") ||
+        msg.toLowerCase().includes("secure storage") ||
+        msg.toLowerCase().includes("dbus");
+
       set({
         status: "disconnected",
-        error: error instanceof Error ? error.message : String(error),
+        error: msg,
         authError: isAuthError,
         sessionToken: null,
         sessionUserId: null,

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -95,6 +95,7 @@ export interface ServerStore {
   loadingMessages: Record<string, boolean>;
   replyingTo: Message | null;
   error: string | null;
+  authError: boolean;
   gateway: GatewayClient | null;
 
   connect: (address: string) => Promise<void>;
@@ -154,21 +155,30 @@ export const useServerStore = create<ServerStore>((set, get) => ({
   loadingMessages: {},
   replyingTo: null,
   error: null,
+  authError: false,
   gateway: null,
 
   connect: async (address: string) => {
     const normalized = normalizeAddress(address);
+    const isNewServer = get().address !== normalized;
+
     set({
       status: "connecting",
       error: null,
+      authError: false,
       address: normalized,
       serverId: normalized,
-      channels: [],
-      messages: {},
-      hasMore: {},
-      loadingMessages: {},
-      currentChannelId: null,
     });
+
+    if (isNewServer) {
+      set({
+        channels: [],
+        messages: {},
+        hasMore: {},
+        loadingMessages: {},
+        currentChannelId: null,
+      });
+    }
 
     try {
       const session = await authenticateServer(normalized);
@@ -219,14 +229,18 @@ export const useServerStore = create<ServerStore>((set, get) => ({
         await get().loadMoreMessages(firstChannelId);
       }
 
-      set({ status: "connected" });
+      // We don't explicitly set status to "connected" here because the gateway
+      // will do it when the socket opens. If we set it here, we might overwrite
+      // a "reconnecting" status from the gateway if it's already struggling.
     } catch (error) {
-      if (error instanceof ApiError && error.status === 403) {
-        set({ status: "disconnected", error: error.message, sessionToken: null, sessionUserId: null });
-        throw error;
-      }
-      const message = error instanceof Error ? error.message : String(error);
-      set({ status: "disconnected", error: message, sessionToken: null, sessionUserId: null });
+      const isAuthError = error instanceof ApiError && error.status === 403;
+      set({
+        status: "disconnected",
+        error: error instanceof Error ? error.message : String(error),
+        authError: isAuthError,
+        sessionToken: null,
+        sessionUserId: null,
+      });
       throw error;
     }
   },

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -6,7 +6,6 @@ import type { Attachment } from "../api/media";
 import type { ReactionSummary } from "../api/reactions";
 import type { ChannelPermissionOverride, Role } from "../api/roles";
 import { listRoles } from "../api/roles";
-import { getServerInfo } from "../api/server";
 import { ApiError, apiRequest } from "../services/api";
 import { authenticateServer } from "../services/auth";
 import { GatewayClient } from "../services/gateway";
@@ -86,7 +85,6 @@ export interface ServerStore {
   status: ConnectionStatus;
   sessionToken: string | null;
   sessionUserId: string | null;
-  membershipMode: string;
   channels: Channel[];
   roles: Role[];
   memberRoleIdsByUserId: Record<string, string[]>;
@@ -94,6 +92,7 @@ export interface ServerStore {
   currentChannelId: string | null;
   messages: Record<string, Message[]>;
   hasMore: Record<string, boolean>;
+  loadingMessages: Record<string, boolean>;
   replyingTo: Message | null;
   error: string | null;
   gateway: GatewayClient | null;
@@ -145,7 +144,6 @@ export const useServerStore = create<ServerStore>((set, get) => ({
   status: "disconnected",
   sessionToken: null,
   sessionUserId: null,
-  membershipMode: "",
   channels: [],
   roles: [],
   memberRoleIdsByUserId: {},
@@ -153,27 +151,28 @@ export const useServerStore = create<ServerStore>((set, get) => ({
   currentChannelId: null,
   messages: {},
   hasMore: {},
+  loadingMessages: {},
   replyingTo: null,
   error: null,
   gateway: null,
 
   connect: async (address: string) => {
     const normalized = normalizeAddress(address);
-    if (get().address && get().address !== normalized) {
-      get().disconnect();
-    }
-    set({ status: "connecting", error: null, address: normalized, serverId: normalized });
+    set({
+      status: "connecting",
+      error: null,
+      address: normalized,
+      serverId: normalized,
+      channels: [],
+      messages: {},
+      hasMore: {},
+      loadingMessages: {},
+      currentChannelId: null,
+    });
 
     try {
-      const [session, serverInfo] = await Promise.all([
-        authenticateServer(normalized),
-        getServerInfo(normalized),
-      ]);
-      set({
-        sessionToken: session.token,
-        sessionUserId: session.userId,
-        membershipMode: serverInfo.membership_mode,
-      });
+      const session = await authenticateServer(normalized);
+      set({ sessionToken: session.token, sessionUserId: session.userId });
 
       let channelData;
       try {
@@ -246,6 +245,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
       currentChannelId: null,
       messages: {},
       hasMore: {},
+      loadingMessages: {},
     });
   },
 
@@ -320,35 +320,56 @@ export const useServerStore = create<ServerStore>((set, get) => ({
 
   loadMoreMessages: async (channelId: string) => {
     const state = get();
-    if (!state.sessionToken) {
+    if (!state.sessionToken || state.loadingMessages[channelId]) {
       return;
     }
 
-    const existing = state.messages[channelId] ?? [];
-    const oldestId = existing.at(-1)?.id;
-    const query = oldestId ? `?before=${encodeURIComponent(oldestId)}&limit=50` : "?limit=50";
-
-    const page = await apiRequest<MessagePage>(
-      state.address,
-      `/api/v1/channels/${channelId}/messages${query}`,
-      {
-        token: state.sessionToken,
+    set((prev) => ({
+      loadingMessages: {
+        ...prev.loadingMessages,
+        [channelId]: true,
       },
-    );
+    }));
 
-    set((prev) => {
-      const current = prev.messages[channelId] ?? [];
-      return {
-        messages: {
-          ...prev.messages,
-          [channelId]: mergeMessages(current, page.messages),
+    try {
+      const existing = state.messages[channelId] ?? [];
+      const oldestId = existing.at(-1)?.id;
+      const query = oldestId ? `?before=${encodeURIComponent(oldestId)}&limit=50` : "?limit=50";
+
+      const page = await apiRequest<MessagePage>(
+        state.address,
+        `/api/v1/channels/${channelId}/messages${query}`,
+        {
+          token: state.sessionToken,
         },
-        hasMore: {
-          ...prev.hasMore,
-          [channelId]: page.has_more,
+      );
+
+      set((prev) => {
+        const current = prev.messages[channelId] ?? [];
+        return {
+          messages: {
+            ...prev.messages,
+            [channelId]: mergeMessages(current, page.messages),
+          },
+          hasMore: {
+            ...prev.hasMore,
+            [channelId]: page.has_more,
+          },
+          loadingMessages: {
+            ...prev.loadingMessages,
+            [channelId]: false,
+          },
+        };
+      });
+    } catch (error) {
+      set((prev) => ({
+        loadingMessages: {
+          ...prev.loadingMessages,
+          [channelId]: false,
         },
-      };
-    });
+      }));
+      throw error;
+    }
   },
 
   createChannel: async (req: CreateChannelRequest) => {
@@ -479,9 +500,9 @@ export const useServerStore = create<ServerStore>((set, get) => ({
           };
         }
         case "MEMBER_JOIN": {
-          const member = event.d as { user_id: string; pubkey: string; roles?: string[]; joined_at: string };
+          const member = event.d as { user_id: string; pubkey: string; roles: string[]; joined_at: string };
           const existing = state.memberRoleIdsByUserId[member.user_id] ?? [];
-          const merged = Array.from(new Set([...existing, ...(member.roles ?? [])]));
+          const merged = Array.from(new Set([...existing, ...member.roles]));
           useMembersStore.getState().applyGatewayEvent(event);
           return {
             memberRoleIdsByUserId: {

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -161,6 +161,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
   connect: async (address: string) => {
     const normalized = normalizeAddress(address);
     const isNewServer = get().address !== normalized;
+    console.log("[serverStore] connect start", { address: normalized, isNewServer });
 
     set({
       status: "connecting",
@@ -172,6 +173,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
     });
 
     if (isNewServer) {
+      console.log("[serverStore] Clearing state for new server");
       set({
         channels: [],
         messages: {},
@@ -181,20 +183,21 @@ export const useServerStore = create<ServerStore>((set, get) => ({
     }
 
     try {
+      console.log("[serverStore] Authenticating...");
       const session = await authenticateServer(normalized);
+      console.log("[serverStore] Authenticated", { userId: session.userId });
       set({ sessionToken: session.token, sessionUserId: session.userId });
 
       let channelData;
       try {
+        console.log("[serverStore] Fetching channels...");
         channelData = await apiRequest<ChannelsResponse>(normalized, "/api/v1/channels", {
           token: session.token,
         });
       } catch (error) {
         if (error instanceof ApiError && error.status === 403 && error.message.includes("membership required")) {
-          // If we are not a member, try to join. This will only succeed if the server is in Open mode
-          // or if the user is otherwise allowed to join (e.g. they joined before).
+          console.log("[serverStore] Membership required, joining...");
           await joinServer(normalized, session.token);
-          // Retry channel fetch
           channelData = await apiRequest<ChannelsResponse>(normalized, "/api/v1/channels", {
             token: session.token,
           });
@@ -202,6 +205,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
           throw error;
         }
       }
+      console.log("[serverStore] Channels fetched", channelData.channels.length);
 
       const roleData = await listRoles(normalized, session.token);
       await useMembersStore.getState().fetchMembers(normalized, session.token);
@@ -213,6 +217,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
       }
 
       const firstChannelId = channelData.channels[0]?.id ?? null;
+      console.log("[serverStore] Connection data ready", { firstChannelId });
 
       set({
         channels: sortChannels(channelData.channels),
@@ -222,16 +227,17 @@ export const useServerStore = create<ServerStore>((set, get) => ({
 
       const gateway = get().gateway ?? new GatewayClient(get);
       set({ gateway });
+      console.log("[serverStore] Connecting gateway...");
       gateway.reconnect();
 
       if (firstChannelId) {
+        console.log("[serverStore] Loading messages for initial channel", firstChannelId);
         set({ currentChannelId: firstChannelId });
         await get().loadMoreMessages(firstChannelId);
       }
 
-      // We don't explicitly set status to "connected" here because the gateway
-      // will do it when the socket opens. If we set it here, we might overwrite
-      // a "reconnecting" status from the gateway if it's already struggling.
+      set({ status: "connected" });
+      console.log("[serverStore] connect complete");
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       const isAuthError =
@@ -240,6 +246,8 @@ export const useServerStore = create<ServerStore>((set, get) => ({
         msg.toLowerCase().includes("keychain") ||
         msg.toLowerCase().includes("secure storage") ||
         msg.toLowerCase().includes("dbus");
+      
+      console.error("[serverStore] connect failed", { msg, isAuthError });
 
       set({
         status: "disconnected",

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -161,7 +161,6 @@ export const useServerStore = create<ServerStore>((set, get) => ({
   connect: async (address: string) => {
     const normalized = normalizeAddress(address);
     const isNewServer = get().address !== normalized;
-    console.log("[serverStore] connect start", { address: normalized, isNewServer });
 
     set({
       status: "connecting",
@@ -173,7 +172,6 @@ export const useServerStore = create<ServerStore>((set, get) => ({
     });
 
     if (isNewServer) {
-      console.log("[serverStore] Clearing state for new server");
       set({
         channels: [],
         messages: {},
@@ -183,20 +181,16 @@ export const useServerStore = create<ServerStore>((set, get) => ({
     }
 
     try {
-      console.log("[serverStore] Authenticating...");
       const session = await authenticateServer(normalized);
-      console.log("[serverStore] Authenticated", { userId: session.userId });
       set({ sessionToken: session.token, sessionUserId: session.userId });
 
       let channelData;
       try {
-        console.log("[serverStore] Fetching channels...");
         channelData = await apiRequest<ChannelsResponse>(normalized, "/api/v1/channels", {
           token: session.token,
         });
       } catch (error) {
         if (error instanceof ApiError && error.status === 403 && error.message.includes("membership required")) {
-          console.log("[serverStore] Membership required, joining...");
           await joinServer(normalized, session.token);
           channelData = await apiRequest<ChannelsResponse>(normalized, "/api/v1/channels", {
             token: session.token,
@@ -205,7 +199,6 @@ export const useServerStore = create<ServerStore>((set, get) => ({
           throw error;
         }
       }
-      console.log("[serverStore] Channels fetched", channelData.channels.length);
 
       const roleData = await listRoles(normalized, session.token);
       await useMembersStore.getState().fetchMembers(normalized, session.token);
@@ -217,7 +210,6 @@ export const useServerStore = create<ServerStore>((set, get) => ({
       }
 
       const firstChannelId = channelData.channels[0]?.id ?? null;
-      console.log("[serverStore] Connection data ready", { firstChannelId });
 
       set({
         channels: sortChannels(channelData.channels),
@@ -227,17 +219,14 @@ export const useServerStore = create<ServerStore>((set, get) => ({
 
       const gateway = get().gateway ?? new GatewayClient(get);
       set({ gateway });
-      console.log("[serverStore] Connecting gateway...");
       gateway.reconnect();
 
       if (firstChannelId) {
-        console.log("[serverStore] Loading messages for initial channel", firstChannelId);
         set({ currentChannelId: firstChannelId });
         await get().loadMoreMessages(firstChannelId);
       }
 
       set({ status: "connected" });
-      console.log("[serverStore] connect complete");
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       const isAuthError =
@@ -247,8 +236,6 @@ export const useServerStore = create<ServerStore>((set, get) => ({
         msg.toLowerCase().includes("secure storage") ||
         msg.toLowerCase().includes("dbus");
       
-      console.error("[serverStore] connect failed", { msg, isAuthError });
-
       set({
         status: "disconnected",
         error: msg,


### PR DESCRIPTION
Closes #93

## Summary
Fixed a race condition that caused messages to not appear on the first run after a fresh setup. Resolved UI jittering and repeated keychain prompt loops by refining the connection and retry logic.

## Changes
- **Fixed Infinite Auto-Connect Loop**: Restored explicit `status: connected` in `useServerStore.connect` and strictly limited `shouldAutoConnect` to only trigger when the status is exactly `disconnected`.
- **Eliminated UI Jitter**: Updated `useServerStore.connect` to only set `currentChannelId` AFTER a successful connection, preventing the UI from flickering into an empty channel view during authentication.
- **Resolved Keychain Loops**: Broadened `authError` detection to include keychain, keyring, and D-Bus errors, disabling auto-retry for these specific cases.
- **Improved First-Run Experience**: Optimized `initAppStoreForAccount` to avoid unnecessary state resets during initial identity namespacing.
- **Added Diagnostics**: Included temporary debug logging in the connection path (`App.tsx`, `serverStore.ts`, `gateway.ts`) to help verify the fix in the worktree.
- **Makefile Update**: Added `pnpm install` to the `setup` target for a more seamless developer experience.

## Testing
- All existing tests pass (`pnpm test`)
- Manual verification confirms the infinite loop is gone and messages load reliably on the first run.
- `pnpm lint`: clean