### PR TITLE
feat: Rust SDK (Base Protocol & Identity) (#85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1144,46 @@ checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "dbus",
  "zeroize",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "decentcom-sdk"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "bip39",
+ "bs58",
+ "chrono",
+ "ed25519-dalek",
+ "futures-util",
+ "hex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "shared",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -1614,6 +1670,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1770,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1845,8 +1917,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1856,9 +1930,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2020,6 +2096,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2209,6 +2304,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2218,6 +2314,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2762,6 +2874,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,6 +3143,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3746,6 +3874,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3962,6 +4145,44 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -4016,6 +4237,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4088,6 +4323,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -5035,7 +5305,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5520,6 +5790,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5538,8 +5818,12 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5809,6 +6093,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -5936,6 +6222,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -6270,6 +6562,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6527,6 +6837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6852,6 +7171,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["server", "shared", "client/src-tauri", "tools/test-setup"]
+members = ["server", "shared", "sdk/rust", "client/src-tauri", "tools/test-setup"]
 
 [workspace.package]
 edition = "2021"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "decentcom-sdk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Rust SDK for the decentcom protocol (identity, REST, and low-level gateway)."
+
+[dependencies]
+shared = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+ed25519-dalek = { workspace = true }
+bs58 = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+hex = { workspace = true }
+bip39 = { version = "2", features = ["rand"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+futures-util = "0.3"
+url = "2"
+
+[dev-dependencies]
+tokio = { workspace = true }
+wiremock = "0.6"

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -1,0 +1,33 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("invalid mnemonic: {0}")]
+    Mnemonic(String),
+
+    #[error("invalid identity input: {0}")]
+    Identity(String),
+
+    #[error("HTTP transport error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("invalid URL: {0}")]
+    Url(#[from] url::ParseError),
+
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+
+    #[error("not authenticated: call Client::authenticate() first")]
+    Unauthenticated,
+
+    #[error("JSON encoding/decoding: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("gateway transport error: {0}")]
+    Gateway(String),
+
+    #[error("protocol error: {0}")]
+    Protocol(String),
+}

--- a/sdk/rust/src/gateway.rs
+++ b/sdk/rust/src/gateway.rs
@@ -1,0 +1,292 @@
+//! Low-level WebSocket gateway client.
+//!
+//! Handles the connection lifecycle, automatic heartbeat acknowledgements,
+//! and surfaces typed server events as a stream. Wire types live in
+//! `shared::gateway`; this module implements the client-side protocol only.
+
+use std::sync::Arc;
+
+use futures_util::{SinkExt, StreamExt};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use shared::gateway::{EmptyData, HelloData, Op, SubscriptionData};
+use tokio::sync::{mpsc, Mutex};
+use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::protocol::Message;
+use url::Url;
+
+use crate::error::{Error, Result};
+
+type WsStream = tokio_tungstenite::WebSocketStream<
+    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+>;
+type WsSink = futures_util::stream::SplitSink<WsStream, Message>;
+
+/// A typed gateway event. The raw envelope is exposed so callers can
+/// deserialize `data` into any payload type relevant to the op code (see
+/// [`GatewayEvent::decode`]).
+#[derive(Debug, Clone)]
+pub struct GatewayEvent {
+    pub op: Op,
+    pub data: Value,
+    pub t: i64,
+}
+
+impl GatewayEvent {
+    /// Decode the `d` field as a specific payload type.
+    pub fn decode<T: DeserializeOwned>(&self) -> Result<T> {
+        serde_json::from_value(self.data.clone()).map_err(Error::Json)
+    }
+}
+
+/// Builder for a [`GatewayClient`].
+#[derive(Debug, Clone)]
+pub struct GatewayBuilder {
+    base_url: Url,
+    token: Option<String>,
+    path: String,
+    auto_heartbeat_ack: bool,
+    event_buffer: usize,
+}
+
+impl GatewayBuilder {
+    pub(crate) fn new(base_url: Url, token: Option<String>) -> Self {
+        Self {
+            base_url,
+            token,
+            path: "/api/v1/gateway".to_string(),
+            auto_heartbeat_ack: true,
+            event_buffer: 256,
+        }
+    }
+
+    /// Override the gateway path (defaults to `/api/v1/gateway`).
+    pub fn path(mut self, path: impl Into<String>) -> Self {
+        self.path = path.into();
+        self
+    }
+
+    /// Disable automatic heartbeat acknowledgement. Callers must respond to
+    /// `Op::Heartbeat` events themselves via [`GatewayClient::send_raw`].
+    pub fn auto_heartbeat_ack(mut self, enabled: bool) -> Self {
+        self.auto_heartbeat_ack = enabled;
+        self
+    }
+
+    /// Size of the channel buffering decoded events.
+    pub fn event_buffer(mut self, size: usize) -> Self {
+        self.event_buffer = size.max(1);
+        self
+    }
+
+    /// Connect to the gateway and spawn the background reader task.
+    pub async fn connect(self) -> Result<GatewayClient> {
+        let token = self.token.ok_or(Error::Unauthenticated)?;
+        let url = build_ws_url(&self.base_url, &self.path, &token)?;
+
+        let (stream, _response) = tokio_tungstenite::connect_async(url.as_str())
+            .await
+            .map_err(|e| Error::Gateway(e.to_string()))?;
+
+        let (sink, mut source) = stream.split();
+        let sink = Arc::new(Mutex::new(sink));
+        let (tx, rx) = mpsc::channel::<GatewayEvent>(self.event_buffer);
+
+        let sink_for_task = sink.clone();
+        let auto_ack = self.auto_heartbeat_ack;
+
+        let reader = tokio::spawn(async move {
+            while let Some(msg) = source.next().await {
+                let msg = match msg {
+                    Ok(m) => m,
+                    Err(_) => break,
+                };
+                let text = match msg {
+                    Message::Text(t) => t,
+                    Message::Binary(b) => match String::from_utf8(b) {
+                        Ok(t) => t,
+                        Err(_) => continue,
+                    },
+                    Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => continue,
+                    Message::Close(_) => break,
+                };
+                let value: Value = match serde_json::from_str(&text) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let op: Op = match value.get("op").cloned().and_then(|v| {
+                    serde_json::from_value::<Op>(v).ok()
+                }) {
+                    Some(op) => op,
+                    None => continue,
+                };
+                let data = value.get("d").cloned().unwrap_or(Value::Null);
+                let t = value.get("t").and_then(Value::as_i64).unwrap_or(0);
+
+                if auto_ack && op == Op::Heartbeat {
+                    let ack =
+                        serde_json::json!({ "op": "HEARTBEAT_ACK", "d": {} }).to_string();
+                    let mut sink = sink_for_task.lock().await;
+                    if sink.send(Message::Text(ack)).await.is_err() {
+                        break;
+                    }
+                }
+
+                if tx.send(GatewayEvent { op, data, t }).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(GatewayClient {
+            sink,
+            rx,
+            reader: Some(reader),
+        })
+    }
+}
+
+fn build_ws_url(base: &Url, path: &str, token: &str) -> Result<Url> {
+    let mut url = base.clone();
+    let target_scheme = match url.scheme() {
+        "https" => "wss",
+        "http" => "ws",
+        "wss" | "ws" => url.scheme(),
+        _ => return Err(Error::Protocol("unsupported base URL scheme".into())),
+    }
+    .to_string();
+    url.set_scheme(&target_scheme)
+        .map_err(|_| Error::Protocol("unsupported base URL scheme".into()))?;
+    url.set_path(path);
+    url.set_query(None);
+    url.query_pairs_mut().append_pair("token", token);
+    Ok(url)
+}
+
+/// A connected WebSocket gateway client with a background reader task.
+pub struct GatewayClient {
+    sink: Arc<Mutex<WsSink>>,
+    rx: mpsc::Receiver<GatewayEvent>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl GatewayClient {
+    /// Receive the next decoded gateway event, or `None` when the connection
+    /// has closed.
+    pub async fn next_event(&mut self) -> Option<GatewayEvent> {
+        self.rx.recv().await
+    }
+
+    /// Wait for the first HELLO event and return its decoded payload.
+    pub async fn wait_for_hello(&mut self) -> Result<HelloData> {
+        loop {
+            match self.next_event().await {
+                Some(ev) if ev.op == Op::Hello => return ev.decode::<HelloData>(),
+                Some(_) => continue,
+                None => {
+                    return Err(Error::Gateway(
+                        "connection closed before hello".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Subscribe to the given channel's event feed.
+    pub async fn subscribe(&self, channel_id: impl Into<String>) -> Result<()> {
+        self.send_command(
+            "SUBSCRIBE",
+            &SubscriptionData {
+                channel_id: channel_id.into(),
+            },
+        )
+        .await
+    }
+
+    /// Unsubscribe from the given channel.
+    pub async fn unsubscribe(&self, channel_id: impl Into<String>) -> Result<()> {
+        self.send_command(
+            "UNSUBSCRIBE",
+            &SubscriptionData {
+                channel_id: channel_id.into(),
+            },
+        )
+        .await
+    }
+
+    /// Send an explicit heartbeat ACK (only needed when automatic ACKs are
+    /// disabled via [`GatewayBuilder::auto_heartbeat_ack`]).
+    pub async fn heartbeat_ack(&self) -> Result<()> {
+        self.send_command("HEARTBEAT_ACK", &EmptyData {}).await
+    }
+
+    /// Send a raw JSON command frame. Most callers should prefer the typed
+    /// helpers above.
+    pub async fn send_raw(&self, value: &Value) -> Result<()> {
+        let text = serde_json::to_string(value)?;
+        let mut sink = self.sink.lock().await;
+        sink.send(Message::Text(text))
+            .await
+            .map_err(|e| Error::Gateway(e.to_string()))
+    }
+
+    async fn send_command<T: Serialize>(&self, op: &str, data: &T) -> Result<()> {
+        let value = serde_json::json!({ "op": op, "d": data });
+        self.send_raw(&value).await
+    }
+
+    /// Close the WebSocket cleanly and stop the reader task.
+    pub async fn close(mut self) -> Result<()> {
+        {
+            let mut sink = self.sink.lock().await;
+            let _ = sink.send(Message::Close(None)).await;
+            let _ = sink.close().await;
+        }
+        if let Some(reader) = self.reader.take() {
+            reader.abort();
+        }
+        Ok(())
+    }
+}
+
+impl Drop for GatewayClient {
+    fn drop(&mut self) {
+        if let Some(reader) = self.reader.take() {
+            reader.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ws_url_http_becomes_ws() {
+        let base = Url::parse("http://localhost:3000/").unwrap();
+        let url = build_ws_url(&base, "/api/v1/gateway", "abc123").unwrap();
+        assert_eq!(url.scheme(), "ws");
+        assert_eq!(url.path(), "/api/v1/gateway");
+        assert_eq!(url.query(), Some("token=abc123"));
+    }
+
+    #[test]
+    fn ws_url_https_becomes_wss() {
+        let base = Url::parse("https://example.com/").unwrap();
+        let url = build_ws_url(&base, "/api/v1/gateway", "t").unwrap();
+        assert_eq!(url.scheme(), "wss");
+    }
+
+    #[test]
+    fn event_decode_roundtrip() {
+        let data = serde_json::json!({ "channel_id": "c1" });
+        let event = GatewayEvent {
+            op: Op::ChannelCreate,
+            data,
+            t: 0,
+        };
+        let decoded: SubscriptionData = event.decode().unwrap();
+        assert_eq!(decoded.channel_id, "c1");
+    }
+}

--- a/sdk/rust/src/identity.rs
+++ b/sdk/rust/src/identity.rs
@@ -1,0 +1,131 @@
+//! Identity management: BIP39 mnemonics, Ed25519 key derivation and signing.
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use bip39::{Language, Mnemonic};
+use ed25519_dalek::{Signer, SigningKey};
+
+use crate::error::{Error, Result};
+
+/// A decentcom identity: an Ed25519 keypair derived from a BIP39 mnemonic or
+/// raw 32-byte seed. The pubkey is encoded as base58 on the wire.
+#[derive(Clone)]
+pub struct Identity {
+    signing_key: SigningKey,
+    pubkey_b58: String,
+}
+
+impl Identity {
+    /// Generate a fresh 24-word BIP39 mnemonic and derive a key from it.
+    pub fn generate() -> Result<(Self, Mnemonic)> {
+        let mnemonic = Mnemonic::generate_in(Language::English, 24)
+            .map_err(|e| Error::Mnemonic(format!("{e:?}")))?;
+        let identity = Self::from_mnemonic(&mnemonic)?;
+        Ok((identity, mnemonic))
+    }
+
+    /// Parse a BIP39 phrase (space-separated words) and derive a key.
+    pub fn from_phrase(phrase: &str) -> Result<Self> {
+        let mnemonic = Mnemonic::parse_in(Language::English, phrase)
+            .map_err(|e| Error::Mnemonic(format!("{e:?}")))?;
+        Self::from_mnemonic(&mnemonic)
+    }
+
+    /// Derive a key from a parsed BIP39 mnemonic.
+    pub fn from_mnemonic(mnemonic: &Mnemonic) -> Result<Self> {
+        let seed = mnemonic.to_seed("");
+        let seed_bytes: [u8; 32] = seed[..32]
+            .try_into()
+            .map_err(|_| Error::Identity("invalid seed length".into()))?;
+        Ok(Self::from_seed(&seed_bytes))
+    }
+
+    /// Build an identity directly from a 32-byte Ed25519 seed.
+    pub fn from_seed(seed: &[u8; 32]) -> Self {
+        let signing_key = SigningKey::from_bytes(seed);
+        let pubkey_b58 = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
+        Self {
+            signing_key,
+            pubkey_b58,
+        }
+    }
+
+    /// Base58-encoded public key, as used on the wire.
+    pub fn pubkey(&self) -> &str {
+        &self.pubkey_b58
+    }
+
+    /// Sign `data` and return the base64-encoded signature (the form the
+    /// server expects in `VerifyRequest`).
+    pub fn sign(&self, data: &[u8]) -> String {
+        let sig = self.signing_key.sign(data);
+        BASE64.encode(sig.to_bytes())
+    }
+
+    /// Raw signing key — exposed for callers that need to sign non-auth
+    /// payloads with the same key material.
+    pub fn signing_key(&self) -> &SigningKey {
+        &self.signing_key
+    }
+}
+
+impl std::fmt::Debug for Identity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Identity")
+            .field("pubkey", &self.pubkey_b58)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Verifier;
+
+    const KNOWN_PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+
+    #[test]
+    fn phrase_derivation_is_deterministic() {
+        let a = Identity::from_phrase(KNOWN_PHRASE).unwrap();
+        let b = Identity::from_phrase(KNOWN_PHRASE).unwrap();
+        assert_eq!(a.pubkey(), b.pubkey());
+        assert!(!a.pubkey().is_empty());
+    }
+
+    #[test]
+    fn seed_derivation_matches_known_output() {
+        let id = Identity::from_seed(&[7u8; 32]);
+        let expected = bs58::encode(
+            SigningKey::from_bytes(&[7u8; 32])
+                .verifying_key()
+                .as_bytes(),
+        )
+        .into_string();
+        assert_eq!(id.pubkey(), expected);
+    }
+
+    #[test]
+    fn sign_produces_valid_base64_signature() {
+        let id = Identity::from_seed(&[1u8; 32]);
+        let sig_b64 = id.sign(b"challenge");
+        let bytes = BASE64.decode(sig_b64).unwrap();
+        let sig = ed25519_dalek::Signature::from_slice(&bytes).unwrap();
+        id.signing_key()
+            .verifying_key()
+            .verify(b"challenge", &sig)
+            .unwrap();
+    }
+
+    #[test]
+    fn invalid_phrase_rejected() {
+        let err = Identity::from_phrase("not a valid mnemonic at all").unwrap_err();
+        assert!(matches!(err, Error::Mnemonic(_)));
+    }
+
+    #[test]
+    fn generate_produces_24_word_phrase() {
+        let (id, mnemonic) = Identity::generate().unwrap();
+        assert_eq!(mnemonic.to_string().split(' ').count(), 24);
+        assert!(!id.pubkey().is_empty());
+    }
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,0 +1,16 @@
+//! Rust SDK for the decentcom protocol.
+//!
+//! Provides identity management, REST API wrappers, and a low-level gateway
+//! (WebSocket) client. Wire types live in the `shared` crate; this crate
+//! implements the logic for speaking the protocol.
+
+pub mod error;
+pub mod identity;
+pub mod rest;
+pub mod gateway;
+
+pub use error::{Error, Result};
+pub use identity::Identity;
+pub use rest::{Client, Config};
+
+pub use shared;

--- a/sdk/rust/src/rest/attachments.rs
+++ b/sdk/rust/src/rest/attachments.rs
@@ -1,0 +1,48 @@
+use reqwest::Method;
+
+use crate::error::{Error, Result};
+use crate::rest::Client;
+
+pub struct AttachmentsApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> AttachmentsApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    /// Fetch raw media bytes by content hash. Returns `(mime_type, bytes)`.
+    ///
+    /// The media endpoint is public — no session token required.
+    pub async fn fetch_media(&self, content_hash: &str) -> Result<(String, Vec<u8>)> {
+        let resp = self
+            .client
+            .request_anonymous(Method::GET, &format!("/api/v1/media/{content_hash}"))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let message = match resp.text().await {
+                Ok(t) => t,
+                Err(e) => e.to_string(),
+            };
+            return Err(Error::Api { status, message });
+        }
+        let mime = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream")
+            .to_string();
+        let bytes = resp.bytes().await?.to_vec();
+        Ok((mime, bytes))
+    }
+
+    /// Build an absolute URL for a media hash (useful for `<img src=...>` in
+    /// downstream apps).
+    pub fn media_url(&self, content_hash: &str) -> String {
+        let base = self.client.base_url().as_str().trim_end_matches('/');
+        format!("{base}/api/v1/media/{content_hash}")
+    }
+}

--- a/sdk/rust/src/rest/auth.rs
+++ b/sdk/rust/src/rest/auth.rs
@@ -1,0 +1,18 @@
+use crate::error::Result;
+use crate::rest::Client;
+
+/// `/api/v1/auth/*` endpoints that aren't covered by [`Client::authenticate`].
+pub struct AuthApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> AuthApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    /// GET `/api/v1/auth/me` — the current session's user id.
+    pub async fn me(&self) -> Result<shared::auth::AuthMeResponse> {
+        self.client.get("/api/v1/auth/me").await
+    }
+}

--- a/sdk/rust/src/rest/channels.rs
+++ b/sdk/rust/src/rest/channels.rs
@@ -1,0 +1,42 @@
+use crate::error::Result;
+use crate::rest::models::{
+    Channel, CreateChannelRequest, ListChannelsResponse, UpdateChannelRequest,
+};
+use crate::rest::Client;
+
+pub struct ChannelsApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> ChannelsApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    pub async fn list(&self) -> Result<Vec<Channel>> {
+        let resp: ListChannelsResponse = self.client.get("/api/v1/channels").await?;
+        Ok(resp.channels)
+    }
+
+    pub async fn create(&self, req: &CreateChannelRequest) -> Result<Channel> {
+        self.client.post("/api/v1/channels", req).await
+    }
+
+    pub async fn get(&self, channel_id: &str) -> Result<Channel> {
+        self.client
+            .get(&format!("/api/v1/channels/{channel_id}"))
+            .await
+    }
+
+    pub async fn update(&self, channel_id: &str, req: &UpdateChannelRequest) -> Result<Channel> {
+        self.client
+            .patch(&format!("/api/v1/channels/{channel_id}"), req)
+            .await
+    }
+
+    pub async fn delete(&self, channel_id: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/api/v1/channels/{channel_id}"))
+            .await
+    }
+}

--- a/sdk/rust/src/rest/invites.rs
+++ b/sdk/rust/src/rest/invites.rs
@@ -1,0 +1,49 @@
+use crate::error::Result;
+use crate::rest::models::{
+    CreateInviteRequest, Invite, InvitePreview, JoinInviteResponse, JoinedMember,
+    ListInvitesResponse,
+};
+use crate::rest::Client;
+
+pub struct InvitesApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> InvitesApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    pub async fn create(&self, req: &CreateInviteRequest) -> Result<Invite> {
+        self.client.post("/api/v1/invites", req).await
+    }
+
+    pub async fn list(&self) -> Result<Vec<Invite>> {
+        let resp: ListInvitesResponse = self.client.get("/api/v1/invites").await?;
+        Ok(resp.invites)
+    }
+
+    /// Invite previews are public — no session required.
+    pub async fn preview(&self, code: &str) -> Result<InvitePreview> {
+        let resp = self
+            .client
+            .request_anonymous(reqwest::Method::GET, &format!("/api/v1/invites/{code}"))
+            .send()
+            .await?;
+        super::decode_response(resp).await
+    }
+
+    pub async fn revoke(&self, code: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/api/v1/invites/{code}"))
+            .await
+    }
+
+    pub async fn join(&self, code: &str) -> Result<JoinedMember> {
+        let resp: JoinInviteResponse = self
+            .client
+            .post_empty(&format!("/api/v1/invites/{code}/join"))
+            .await?;
+        Ok(resp.member)
+    }
+}

--- a/sdk/rust/src/rest/members.rs
+++ b/sdk/rust/src/rest/members.rs
@@ -1,0 +1,101 @@
+use crate::error::Result;
+use crate::rest::models::{
+    AllowlistEntry, AllowlistRequest, ApproveBotRequest, Ban, BanRequest, BotApproval,
+    JoinMemberResponse, ListAllowlistResponse, ListBansResponse, ListMembersResponse,
+    ListPendingBotsResponse, Member,
+};
+use crate::rest::Client;
+
+pub struct MembersApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> MembersApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    pub async fn list(&self) -> Result<Vec<Member>> {
+        let resp: ListMembersResponse = self.client.get("/api/v1/members").await?;
+        Ok(resp.members)
+    }
+
+    pub async fn get(&self, pubkey: &str) -> Result<Member> {
+        self.client
+            .get(&format!("/api/v1/members/{pubkey}"))
+            .await
+    }
+
+    /// POST `/api/v1/members/join` — join the server as the authenticated user.
+    pub async fn join(&self) -> Result<Member> {
+        let resp: JoinMemberResponse = self.client.post_empty("/api/v1/members/join").await?;
+        Ok(resp.member)
+    }
+
+    pub async fn leave(&self) -> Result<()> {
+        self.client.delete("/api/v1/members/me").await
+    }
+
+    pub async fn kick(&self, pubkey: &str) -> Result<()> {
+        self.client
+            .send_empty(
+                reqwest::Method::POST,
+                &format!("/api/v1/members/{pubkey}/kick"),
+            )
+            .await
+    }
+
+    pub async fn ban(&self, pubkey: &str, req: &BanRequest) -> Result<Ban> {
+        self.client
+            .post(&format!("/api/v1/members/{pubkey}/ban"), req)
+            .await
+    }
+
+    pub async fn list_bans(&self) -> Result<Vec<Ban>> {
+        let resp: ListBansResponse = self.client.get("/api/v1/bans").await?;
+        Ok(resp.bans)
+    }
+
+    pub async fn unban(&self, pubkey: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/api/v1/bans/{pubkey}"))
+            .await
+    }
+
+    pub async fn list_allowlist(&self) -> Result<Vec<AllowlistEntry>> {
+        let resp: ListAllowlistResponse = self.client.get("/api/v1/allowlist").await?;
+        Ok(resp.entries)
+    }
+
+    pub async fn add_allowlist(&self, pubkey: impl Into<String>) -> Result<AllowlistEntry> {
+        let body = AllowlistRequest { pubkey: pubkey.into() };
+        self.client.post("/api/v1/allowlist", &body).await
+    }
+
+    pub async fn remove_allowlist(&self, pubkey: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/api/v1/allowlist/{pubkey}"))
+            .await
+    }
+
+    pub async fn list_pending_bots(&self) -> Result<Vec<BotApproval>> {
+        let resp: ListPendingBotsResponse = self.client.get("/api/v1/admin/bots/pending").await?;
+        Ok(resp.bots)
+    }
+
+    pub async fn approve_bot(
+        &self,
+        pubkey: &str,
+        req: &ApproveBotRequest,
+    ) -> Result<BotApproval> {
+        self.client
+            .post(&format!("/api/v1/admin/bots/{pubkey}/approve"), req)
+            .await
+    }
+
+    pub async fn revoke_bot(&self, pubkey: &str) -> Result<BotApproval> {
+        self.client
+            .post_empty(&format!("/api/v1/admin/bots/{pubkey}/revoke"))
+            .await
+    }
+}

--- a/sdk/rust/src/rest/messages.rs
+++ b/sdk/rust/src/rest/messages.rs
@@ -1,0 +1,71 @@
+use reqwest::Method;
+
+use crate::error::Result;
+use crate::rest::models::{
+    CreateMessageRequest, ListMessagesQuery, Message, MessagePage, UpdateMessageRequest,
+};
+use crate::rest::Client;
+
+pub struct MessagesApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> MessagesApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    /// Send a message to a channel. Pass `attachment_ids` inside
+    /// [`CreateMessageRequest`] if the message carries attachments.
+    pub async fn send(&self, channel_id: &str, req: &CreateMessageRequest) -> Result<Message> {
+        self.client
+            .post(&format!("/api/v1/channels/{channel_id}/messages"), req)
+            .await
+    }
+
+    /// Convenience: send a plain-text message with no attachments.
+    pub async fn send_text(&self, channel_id: &str, content: impl Into<String>) -> Result<Message> {
+        let req = CreateMessageRequest {
+            content: content.into(),
+            attachment_ids: Vec::new(),
+        };
+        self.send(channel_id, &req).await
+    }
+
+    pub async fn list(&self, channel_id: &str, query: &ListMessagesQuery) -> Result<MessagePage> {
+        let path = format!("/api/v1/channels/{channel_id}/messages");
+        let req = self.client.request(Method::GET, &path)?.query(query);
+        let resp = req.send().await?;
+        super::decode_response(resp).await
+    }
+
+    pub async fn get(&self, channel_id: &str, message_id: &str) -> Result<Message> {
+        self.client
+            .get(&format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}"
+            ))
+            .await
+    }
+
+    pub async fn update(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        req: &UpdateMessageRequest,
+    ) -> Result<Message> {
+        self.client
+            .patch(
+                &format!("/api/v1/channels/{channel_id}/messages/{message_id}"),
+                req,
+            )
+            .await
+    }
+
+    pub async fn delete(&self, channel_id: &str, message_id: &str) -> Result<()> {
+        self.client
+            .delete(&format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}"
+            ))
+            .await
+    }
+}

--- a/sdk/rust/src/rest/mod.rs
+++ b/sdk/rust/src/rest/mod.rs
@@ -1,0 +1,301 @@
+//! REST API wrappers for the decentcom server.
+
+pub mod attachments;
+pub mod auth;
+pub mod channels;
+pub mod invites;
+pub mod members;
+pub mod messages;
+pub mod models;
+pub mod profiles;
+pub mod reactions;
+pub mod roles;
+pub mod threads;
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use reqwest::{header, Method, RequestBuilder, StatusCode};
+use serde::{de::DeserializeOwned, Serialize};
+use url::Url;
+
+use crate::error::{Error, Result};
+use crate::identity::Identity;
+
+/// Configuration for a [`Client`].
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub base_url: Url,
+    pub timeout: Duration,
+    pub user_agent: String,
+}
+
+impl Config {
+    pub fn new(base_url: impl Into<String>) -> Result<Self> {
+        let parsed = Url::parse(&base_url.into())?;
+        Ok(Self {
+            base_url: parsed,
+            timeout: Duration::from_secs(30),
+            user_agent: format!("decentcom-sdk/{}", env!("CARGO_PKG_VERSION")),
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct SessionState {
+    token: Option<String>,
+    user_id: Option<String>,
+}
+
+/// Typed, session-aware REST client for a single decentcom server.
+///
+/// Multiple `Client` instances can be constructed independently to manage
+/// sessions with multiple servers in parallel.
+#[derive(Debug, Clone)]
+pub struct Client {
+    http: reqwest::Client,
+    config: Arc<Config>,
+    session: Arc<RwLock<SessionState>>,
+}
+
+impl Client {
+    pub fn new(base_url: impl Into<String>) -> Result<Self> {
+        Self::with_config(Config::new(base_url)?)
+    }
+
+    pub fn with_config(config: Config) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .user_agent(&config.user_agent)
+            .timeout(config.timeout)
+            .build()?;
+        Ok(Self {
+            http,
+            config: Arc::new(config),
+            session: Arc::new(RwLock::new(SessionState::default())),
+        })
+    }
+
+    pub fn base_url(&self) -> &Url {
+        &self.config.base_url
+    }
+
+    /// Perform the two-step challenge-response auth flow and store the
+    /// resulting session token on this client.
+    pub async fn authenticate(&self, identity: &Identity) -> Result<shared::auth::VerifyResponse> {
+        self.authenticate_as(identity, false).await
+    }
+
+    /// Authenticate as a bot (the server binds `"|bot"` into the challenge
+    /// text, so signing the returned challenge produces a bot claim).
+    pub async fn authenticate_as_bot(
+        &self,
+        identity: &Identity,
+    ) -> Result<shared::auth::VerifyResponse> {
+        self.authenticate_as(identity, true).await
+    }
+
+    async fn authenticate_as(
+        &self,
+        identity: &Identity,
+        is_bot: bool,
+    ) -> Result<shared::auth::VerifyResponse> {
+        let challenge_resp = self
+            .request_anonymous(Method::POST, "/api/v1/auth/challenge")
+            .json(&shared::auth::ChallengeRequest {
+                pubkey: identity.pubkey().to_owned(),
+                is_bot,
+            })
+            .send()
+            .await?;
+        let challenge: shared::auth::ChallengeResponse = decode_response(challenge_resp).await?;
+
+        let signature = identity.sign(challenge.challenge.as_bytes());
+        let verify_resp = self
+            .request_anonymous(Method::POST, "/api/v1/auth/verify")
+            .json(&shared::auth::VerifyRequest {
+                pubkey: identity.pubkey().to_owned(),
+                signature,
+            })
+            .send()
+            .await?;
+        let verified: shared::auth::VerifyResponse = decode_response(verify_resp).await?;
+
+        self.set_session(Some(verified.token.clone()), Some(verified.user_id.clone()));
+        Ok(verified)
+    }
+
+    /// Replace the session manually (e.g. restoring from storage).
+    pub fn set_session(&self, token: Option<String>, user_id: Option<String>) {
+        let mut s = self.session.write().expect("sdk session rwlock poisoned");
+        s.token = token;
+        s.user_id = user_id;
+    }
+
+    pub fn session_token(&self) -> Option<String> {
+        self.session
+            .read()
+            .expect("sdk session rwlock poisoned")
+            .token
+            .clone()
+    }
+
+    pub fn user_id(&self) -> Option<String> {
+        self.session
+            .read()
+            .expect("sdk session rwlock poisoned")
+            .user_id
+            .clone()
+    }
+
+    // ── Typed module entry points ──────────────────────────────────────────
+
+    pub fn auth(&self) -> auth::AuthApi<'_> {
+        auth::AuthApi::new(self)
+    }
+    pub fn channels(&self) -> channels::ChannelsApi<'_> {
+        channels::ChannelsApi::new(self)
+    }
+    pub fn messages(&self) -> messages::MessagesApi<'_> {
+        messages::MessagesApi::new(self)
+    }
+    pub fn members(&self) -> members::MembersApi<'_> {
+        members::MembersApi::new(self)
+    }
+    pub fn roles(&self) -> roles::RolesApi<'_> {
+        roles::RolesApi::new(self)
+    }
+    pub fn profiles(&self) -> profiles::ProfilesApi<'_> {
+        profiles::ProfilesApi::new(self)
+    }
+    pub fn invites(&self) -> invites::InvitesApi<'_> {
+        invites::InvitesApi::new(self)
+    }
+    pub fn threads(&self) -> threads::ThreadsApi<'_> {
+        threads::ThreadsApi::new(self)
+    }
+    pub fn reactions(&self) -> reactions::ReactionsApi<'_> {
+        reactions::ReactionsApi::new(self)
+    }
+    pub fn attachments(&self) -> attachments::AttachmentsApi<'_> {
+        attachments::AttachmentsApi::new(self)
+    }
+
+    /// Build the low-level gateway (WebSocket) client, using the current
+    /// session token. Returns an error if not authenticated.
+    pub fn gateway(&self) -> crate::gateway::GatewayBuilder {
+        crate::gateway::GatewayBuilder::new(self.config.base_url.clone(), self.session_token())
+    }
+
+    // ── Internal request helpers ───────────────────────────────────────────
+
+    pub(crate) fn request_anonymous(&self, method: Method, path: &str) -> RequestBuilder {
+        let url = self
+            .config
+            .base_url
+            .join(path.trim_start_matches('/'))
+            .expect("valid path");
+        self.http.request(method, url)
+    }
+
+    pub(crate) fn request(&self, method: Method, path: &str) -> Result<RequestBuilder> {
+        let token = self.session_token().ok_or(Error::Unauthenticated)?;
+        Ok(self
+            .request_anonymous(method, path)
+            .header(header::AUTHORIZATION, format!("Bearer {token}")))
+    }
+
+    pub(crate) async fn send_json<B: Serialize, T: DeserializeOwned>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&B>,
+    ) -> Result<T> {
+        let mut req = self.request(method, path)?;
+        if let Some(body) = body {
+            req = req.json(body);
+        }
+        let resp = req.send().await?;
+        decode_response(resp).await
+    }
+
+    pub(crate) async fn send_empty(&self, method: Method, path: &str) -> Result<()> {
+        let resp = self.request(method, path)?.send().await?;
+        check_status(resp).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        self.send_json::<(), T>(Method::GET, path, None).await
+    }
+
+    pub(crate) async fn post<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        self.send_json(Method::POST, path, Some(body)).await
+    }
+
+    pub(crate) async fn post_empty<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        self.send_json::<(), T>(Method::POST, path, None).await
+    }
+
+    pub(crate) async fn patch<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        self.send_json(Method::PATCH, path, Some(body)).await
+    }
+
+    pub(crate) async fn put<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        self.send_json(Method::PUT, path, Some(body)).await
+    }
+
+    pub(crate) async fn put_empty(&self, path: &str) -> Result<()> {
+        self.send_empty(Method::PUT, path).await
+    }
+
+    pub(crate) async fn delete(&self, path: &str) -> Result<()> {
+        self.send_empty(Method::DELETE, path).await
+    }
+}
+
+async fn check_status(resp: reqwest::Response) -> Result<reqwest::Response> {
+    if resp.status().is_success() {
+        return Ok(resp);
+    }
+    let status = resp.status().as_u16();
+    let message = extract_error_message(resp).await;
+    Err(Error::Api { status, message })
+}
+
+async fn decode_response<T: DeserializeOwned>(resp: reqwest::Response) -> Result<T> {
+    let resp = check_status(resp).await?;
+    if resp.status() == StatusCode::NO_CONTENT {
+        // 204 responses carry no body; try to decode `null` or `{}` so callers
+        // using `Unit`/empty-struct response types still work.
+        let empty = serde_json::from_str::<T>("null")
+            .or_else(|_| serde_json::from_str::<T>("{}"));
+        return empty.map_err(Error::Json);
+    }
+    Ok(resp.json::<T>().await?)
+}
+
+async fn extract_error_message(resp: reqwest::Response) -> String {
+    match resp.text().await {
+        Ok(text) => {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+                if let Some(msg) = v.get("error").and_then(|e| e.as_str()) {
+                    return msg.to_string();
+                }
+            }
+            text
+        }
+        Err(e) => e.to_string(),
+    }
+}

--- a/sdk/rust/src/rest/models.rs
+++ b/sdk/rust/src/rest/models.rs
@@ -1,0 +1,372 @@
+//! Wire types for REST request and response bodies.
+//!
+//! These mirror the server-side types in `server/src/**/models.rs` without
+//! depending on the server crate. Field names and semantics must stay in
+//! lockstep with the server.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// ── Channels ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateChannelRequest {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<i32>,
+}
+
+/// PATCH body for a channel. Use `None` to leave a field alone; use
+/// `Some(None)` on `category` to clear it explicitly (matches the server's
+/// three-valued semantics).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateChannelRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Channel {
+    pub id: String,
+    pub name: String,
+    pub topic: Option<String>,
+    pub category: Option<String>,
+    pub position: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(rename = "type")]
+    pub channel_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListChannelsResponse {
+    pub channels: Vec<Channel>,
+}
+
+// ── Messages ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateMessageRequest {
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachment_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateMessageRequest {
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ListMessagesQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReactionSummary {
+    pub emoji: String,
+    pub count: i64,
+    pub me: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadSummary {
+    pub thread_id: String,
+    pub reply_count: i64,
+    pub last_reply_at: Option<DateTime<Utc>>,
+    pub last_reply_author_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub id: String,
+    pub channel_id: String,
+    pub author_id: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub edited_at: Option<DateTime<Utc>>,
+    pub deleted: bool,
+    pub attachments: Vec<Attachment>,
+    pub reactions: Vec<ReactionSummary>,
+    pub thread: Option<ThreadSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessagePage {
+    pub messages: Vec<Message>,
+    pub has_more: bool,
+}
+
+// ── Members ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoleRef {
+    pub id: String,
+    pub name: String,
+    pub color: Option<String>,
+    pub position: i32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Member {
+    pub user_id: String,
+    pub pubkey: String,
+    pub display_name: Option<String>,
+    pub avatar_hash: Option<String>,
+    pub is_bot: bool,
+    pub joined_at: DateTime<Utc>,
+    pub roles: Vec<RoleRef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListMembersResponse {
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct JoinMemberResponse {
+    pub member: Member,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BanRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Ban {
+    pub pubkey: String,
+    pub banned_by: String,
+    pub reason: Option<String>,
+    pub banned_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListBansResponse {
+    pub bans: Vec<Ban>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AllowlistRequest {
+    pub pubkey: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AllowlistEntry {
+    pub pubkey: String,
+    pub added_by: String,
+    pub added_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListAllowlistResponse {
+    pub entries: Vec<AllowlistEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BotApproval {
+    pub pubkey: String,
+    pub approved_by: Option<String>,
+    pub approved_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListPendingBotsResponse {
+    pub bots: Vec<BotApproval>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ApproveBotRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+// ── Roles ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateRoleRequest {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    pub permissions: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<i32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateRoleRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Role {
+    pub id: String,
+    pub name: String,
+    pub color: Option<String>,
+    pub permissions: i64,
+    pub position: i32,
+    pub is_builtin: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListRolesResponse {
+    pub roles: Vec<Role>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SetChannelOverrideRequest {
+    pub allow: i64,
+    pub deny: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelOverride {
+    pub channel_id: String,
+    pub role_id: String,
+    pub allow: i64,
+    pub deny: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListChannelOverridesResponse {
+    pub overrides: Vec<ChannelOverride>,
+}
+
+// ── Profiles ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateProfileRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Profile {
+    pub user_id: String,
+    pub pubkey: String,
+    pub display_name: Option<String>,
+    pub avatar_hash: Option<String>,
+    pub joined_at: Option<String>,
+    pub roles: Vec<RoleRef>,
+}
+
+// ── Invites ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CreateInviteRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_uses: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_in_seconds: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grant_role_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Invite {
+    pub code: String,
+    pub created_by: String,
+    pub grant_role_id: Option<String>,
+    pub max_uses: i64,
+    pub use_count: i64,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub invite_link: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListInvitesResponse {
+    pub invites: Vec<Invite>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct InvitePreview {
+    pub code: String,
+    pub server_name: String,
+    pub server_icon: Option<String>,
+    pub member_count: usize,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct JoinedMember {
+    pub pubkey: String,
+    pub roles: Vec<String>,
+    pub joined_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct JoinInviteResponse {
+    pub member: JoinedMember,
+}
+
+// ── Threads ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateThreadResponse {
+    pub thread_id: String,
+    pub parent_message_id: String,
+    pub channel_id: String,
+    pub created_at: DateTime<Utc>,
+    pub reply_count: i64,
+    pub follower_count: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Thread {
+    pub id: String,
+    pub channel_id: String,
+    pub parent_message_id: String,
+    pub creator_id: String,
+    pub created_at: DateTime<Utc>,
+    pub last_reply_at: Option<DateTime<Utc>>,
+    pub reply_count: i64,
+    pub follower_count: i64,
+    pub is_following: bool,
+}
+
+// ── Attachments ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Attachment {
+    pub id: String,
+    pub message_id: Option<String>,
+    pub channel_id: String,
+    pub uploader_id: String,
+    pub filename: String,
+    pub content_hash: String,
+    pub size: i64,
+    pub mime_type: String,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+    pub created_at: DateTime<Utc>,
+}
+
+// ── Server info ────────────────────────────────────────────────────────────
+
+pub use shared::ServerInfo;

--- a/sdk/rust/src/rest/profiles.rs
+++ b/sdk/rust/src/rest/profiles.rs
@@ -1,0 +1,32 @@
+use crate::error::Result;
+use crate::rest::models::{Profile, UpdateProfileRequest};
+use crate::rest::Client;
+
+pub struct ProfilesApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> ProfilesApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    pub async fn update(&self, req: &UpdateProfileRequest) -> Result<Profile> {
+        self.client.patch("/api/v1/profile", req).await
+    }
+
+    pub async fn delete_avatar(&self) -> Result<Profile> {
+        // Handler returns JSON profile, so we can't use the empty-body helper.
+        let req = self
+            .client
+            .request(reqwest::Method::DELETE, "/api/v1/profile/avatar")?;
+        let resp = req.send().await?;
+        super::decode_response(resp).await
+    }
+
+    pub async fn get_member_profile(&self, pubkey: &str) -> Result<Profile> {
+        self.client
+            .get(&format!("/api/v1/members/{pubkey}/profile"))
+            .await
+    }
+}

--- a/sdk/rust/src/rest/reactions.rs
+++ b/sdk/rust/src/rest/reactions.rs
@@ -1,0 +1,92 @@
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::rest::Client;
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ListReactorsQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReactorEntry {
+    pub id: String,
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListReactorsResponse {
+    pub users: Vec<ReactorEntry>,
+    pub total: usize,
+}
+
+pub struct ReactionsApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> ReactionsApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    /// PUT — add or toggle a reaction with the given emoji.
+    pub async fn add(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> Result<()> {
+        self.client
+            .put_empty(&format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}/reactions/{emoji}"
+            ))
+            .await
+    }
+
+    /// DELETE — remove the authenticated user's reaction on this message.
+    pub async fn remove_own(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+    ) -> Result<()> {
+        self.client
+            .delete(&format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}/reactions"
+            ))
+            .await
+    }
+
+    /// DELETE — remove another user's reaction (requires `MANAGE_MESSAGES`).
+    pub async fn remove_user(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        user_id: &str,
+    ) -> Result<()> {
+        self.client
+            .delete(&format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}/reactions/users/{user_id}"
+            ))
+            .await
+    }
+
+    /// GET — list users who reacted with the given emoji.
+    pub async fn list_reactors(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
+        query: &ListReactorsQuery,
+    ) -> Result<ListReactorsResponse> {
+        let path = format!(
+            "/api/v1/channels/{channel_id}/messages/{message_id}/reactions/{emoji}"
+        );
+        let req = self.client.request(Method::GET, &path)?.query(query);
+        let resp = req.send().await?;
+        super::decode_response(resp).await
+    }
+}

--- a/sdk/rust/src/rest/roles.rs
+++ b/sdk/rust/src/rest/roles.rs
@@ -1,0 +1,86 @@
+use crate::error::Result;
+use crate::rest::models::{
+    ChannelOverride, CreateRoleRequest, ListChannelOverridesResponse, ListRolesResponse, Role,
+    SetChannelOverrideRequest, UpdateRoleRequest,
+};
+use crate::rest::Client;
+
+pub struct RolesApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> RolesApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    pub async fn list(&self) -> Result<Vec<Role>> {
+        let resp: ListRolesResponse = self.client.get("/api/v1/roles").await?;
+        Ok(resp.roles)
+    }
+
+    pub async fn create(&self, req: &CreateRoleRequest) -> Result<Role> {
+        self.client.post("/api/v1/roles", req).await
+    }
+
+    pub async fn update(&self, role_id: &str, req: &UpdateRoleRequest) -> Result<Role> {
+        self.client
+            .patch(&format!("/api/v1/roles/{role_id}"), req)
+            .await
+    }
+
+    pub async fn delete(&self, role_id: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/api/v1/roles/{role_id}"))
+            .await
+    }
+
+    pub async fn add_member_role(&self, pubkey: &str, role_id: &str) -> Result<()> {
+        self.client
+            .put_empty(&format!("/api/v1/members/{pubkey}/roles/{role_id}"))
+            .await
+    }
+
+    pub async fn remove_member_role(&self, pubkey: &str, role_id: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/api/v1/members/{pubkey}/roles/{role_id}"))
+            .await
+    }
+
+    pub async fn list_channel_overrides(
+        &self,
+        channel_id: &str,
+    ) -> Result<Vec<ChannelOverride>> {
+        let resp: ListChannelOverridesResponse = self
+            .client
+            .get(&format!("/api/v1/channels/{channel_id}/overrides"))
+            .await?;
+        Ok(resp.overrides)
+    }
+
+    pub async fn set_channel_override(
+        &self,
+        channel_id: &str,
+        role_id: &str,
+        req: &SetChannelOverrideRequest,
+    ) -> Result<ChannelOverride> {
+        self.client
+            .put(
+                &format!("/api/v1/channels/{channel_id}/overrides/{role_id}"),
+                req,
+            )
+            .await
+    }
+
+    pub async fn delete_channel_override(
+        &self,
+        channel_id: &str,
+        role_id: &str,
+    ) -> Result<()> {
+        self.client
+            .delete(&format!(
+                "/api/v1/channels/{channel_id}/overrides/{role_id}"
+            ))
+            .await
+    }
+}

--- a/sdk/rust/src/rest/threads.rs
+++ b/sdk/rust/src/rest/threads.rs
@@ -1,0 +1,74 @@
+use reqwest::Method;
+
+use crate::error::Result;
+use crate::rest::models::{
+    CreateMessageRequest, CreateThreadResponse, ListMessagesQuery, Message, MessagePage, Thread,
+};
+use crate::rest::Client;
+
+pub struct ThreadsApi<'c> {
+    client: &'c Client,
+}
+
+impl<'c> ThreadsApi<'c> {
+    pub(crate) fn new(client: &'c Client) -> Self {
+        Self { client }
+    }
+
+    pub async fn create(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+    ) -> Result<CreateThreadResponse> {
+        self.client
+            .post_empty(&format!(
+                "/api/v1/channels/{channel_id}/messages/{message_id}/threads"
+            ))
+            .await
+    }
+
+    pub async fn get(&self, thread_id: &str) -> Result<Thread> {
+        self.client
+            .get(&format!("/api/v1/threads/{thread_id}"))
+            .await
+    }
+
+    pub async fn list_messages(
+        &self,
+        thread_id: &str,
+        query: &ListMessagesQuery,
+    ) -> Result<MessagePage> {
+        let path = format!("/api/v1/threads/{thread_id}/messages");
+        let req = self.client.request(Method::GET, &path)?.query(query);
+        let resp = req.send().await?;
+        super::decode_response(resp).await
+    }
+
+    pub async fn post_message(
+        &self,
+        thread_id: &str,
+        req: &CreateMessageRequest,
+    ) -> Result<Message> {
+        self.client
+            .post(&format!("/api/v1/threads/{thread_id}/messages"), req)
+            .await
+    }
+
+    pub async fn follow(&self, thread_id: &str) -> Result<()> {
+        self.client
+            .put_empty(&format!("/api/v1/threads/{thread_id}/follow"))
+            .await
+    }
+
+    pub async fn unfollow(&self, thread_id: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/api/v1/threads/{thread_id}/follow"))
+            .await
+    }
+
+    pub async fn mark_read(&self, thread_id: &str) -> Result<()> {
+        self.client
+            .put_empty(&format!("/api/v1/threads/{thread_id}/read"))
+            .await
+    }
+}

--- a/sdk/rust/tests/rest.rs
+++ b/sdk/rust/tests/rest.rs
@@ -1,0 +1,266 @@
+//! Integration tests for the REST client using a mocked HTTP server.
+//!
+//! These tests exercise the full request pipeline — URL construction, auth
+//! header injection, JSON encoding/decoding, and response handling — against
+//! `wiremock` stubs.
+
+use decentcom_sdk::rest::models::{
+    Channel, CreateChannelRequest, CreateMessageRequest, ListChannelsResponse, MessagePage,
+};
+use decentcom_sdk::{Client, Identity};
+use serde_json::json;
+use wiremock::matchers::{body_json, header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+async fn make_client(server: &MockServer) -> Client {
+    Client::new(server.uri()).expect("client")
+}
+
+#[tokio::test]
+async fn authenticate_performs_challenge_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/auth/challenge"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "challenge": "sign-me",
+            "expires_at": "2026-04-18T00:00:00Z",
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/auth/verify"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "token": "session-token-xyz",
+            "user_id": "u1",
+            "pubkey": "pk1",
+            "expires_at": "2026-05-18T00:00:00Z",
+        })))
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server).await;
+    let (identity, _mnemonic) = Identity::generate().expect("generate");
+    let verified = client.authenticate(&identity).await.expect("authenticate");
+    assert_eq!(verified.token, "session-token-xyz");
+    assert_eq!(client.session_token().as_deref(), Some("session-token-xyz"));
+    assert_eq!(client.user_id().as_deref(), Some("u1"));
+}
+
+#[tokio::test]
+async fn list_channels_sends_bearer_and_parses_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/channels"))
+        .and(header("authorization", "Bearer test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "channels": [
+                {
+                    "id": "c1",
+                    "name": "general",
+                    "topic": null,
+                    "category": null,
+                    "position": 0,
+                    "created_at": "2026-04-18T00:00:00Z",
+                    "updated_at": "2026-04-18T00:00:00Z",
+                    "type": "text"
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server).await;
+    client.set_session(Some("test-token".into()), Some("u1".into()));
+    let channels = client.channels().list().await.expect("list");
+    assert_eq!(channels.len(), 1);
+    assert_eq!(channels[0].name, "general");
+}
+
+#[tokio::test]
+async fn create_channel_posts_json_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/channels"))
+        .and(header("authorization", "Bearer t"))
+        .and(body_json(json!({ "name": "chat", "category": "General" })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": "c2",
+            "name": "chat",
+            "topic": null,
+            "category": "General",
+            "position": 1,
+            "created_at": "2026-04-18T00:00:00Z",
+            "updated_at": "2026-04-18T00:00:00Z",
+            "type": "text"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server).await;
+    client.set_session(Some("t".into()), Some("u1".into()));
+    let req = CreateChannelRequest {
+        name: "chat".into(),
+        category: Some("General".into()),
+        position: None,
+    };
+    let channel = client.channels().create(&req).await.expect("create");
+    assert_eq!(channel.id, "c2");
+    assert_eq!(channel.category.as_deref(), Some("General"));
+}
+
+#[tokio::test]
+async fn list_messages_forwards_query_params() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/channels/c1/messages"))
+        .and(query_param("limit", "10"))
+        .and(query_param("before", "msg-5"))
+        .and(header("authorization", "Bearer t"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "messages": [],
+            "has_more": false
+        })))
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server).await;
+    client.set_session(Some("t".into()), Some("u1".into()));
+    let query = decentcom_sdk::rest::models::ListMessagesQuery {
+        before: Some("msg-5".into()),
+        after: None,
+        limit: Some(10),
+    };
+    let page: MessagePage = client
+        .messages()
+        .list("c1", &query)
+        .await
+        .expect("list messages");
+    assert!(page.messages.is_empty());
+    assert!(!page.has_more);
+}
+
+#[tokio::test]
+async fn send_message_posts_body_with_empty_attachments() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/channels/c1/messages"))
+        .and(body_json(json!({ "content": "hi" })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": "m1",
+            "channel_id": "c1",
+            "author_id": "u1",
+            "content": "hi",
+            "created_at": "2026-04-18T00:00:00Z",
+            "edited_at": null,
+            "deleted": false,
+            "attachments": [],
+            "reactions": [],
+            "thread": null
+        })))
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server).await;
+    client.set_session(Some("t".into()), Some("u1".into()));
+    let msg = client
+        .messages()
+        .send_text("c1", "hi")
+        .await
+        .expect("send text");
+    assert_eq!(msg.id, "m1");
+    assert_eq!(msg.content, "hi");
+}
+
+#[tokio::test]
+async fn api_error_returns_parsed_message() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/channels"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+            "error": "missing read_messages permission"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server).await;
+    client.set_session(Some("t".into()), Some("u1".into()));
+    let err = client.channels().list().await.expect_err("should error");
+    match err {
+        decentcom_sdk::Error::Api { status, message } => {
+            assert_eq!(status, 403);
+            assert_eq!(message, "missing read_messages permission");
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unauthenticated_calls_fail_without_token() {
+    let server = MockServer::start().await;
+    let client = make_client(&server).await;
+    let err = client.channels().list().await.expect_err("should error");
+    assert!(matches!(err, decentcom_sdk::Error::Unauthenticated));
+}
+
+#[tokio::test]
+async fn invite_preview_uses_anonymous_request() {
+    let server = MockServer::start().await;
+
+    // Note: no authorization header on this mock — we assert that preview
+    // works even when the client has no session token.
+    Mock::given(method("GET"))
+        .and(path("/api/v1/invites/ABC123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "ABC123",
+            "server_name": "Test",
+            "server_icon": null,
+            "member_count": 42,
+            "expires_at": null
+        })))
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server).await;
+    let preview = client.invites().preview("ABC123").await.expect("preview");
+    assert_eq!(preview.code, "ABC123");
+    assert_eq!(preview.member_count, 42);
+}
+
+#[tokio::test]
+async fn media_url_builds_absolute_path() {
+    let server = MockServer::start().await;
+    let client = make_client(&server).await;
+    let url = client.attachments().media_url("abc123");
+    assert_eq!(url, format!("{}/api/v1/media/abc123", server.uri()));
+}
+
+#[tokio::test]
+async fn delete_returns_no_content() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/api/v1/channels/c1"))
+        .and(header("authorization", "Bearer t"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server).await;
+    client.set_session(Some("t".into()), Some("u1".into()));
+    client.channels().delete("c1").await.expect("delete");
+}
+
+// Dummy use to satisfy imports in a shared way.
+#[allow(dead_code)]
+fn _types_are_public() {
+    let _: Option<Channel> = None;
+    let _: Option<ListChannelsResponse> = None;
+    let _: Option<CreateMessageRequest> = None;
+}

--- a/server/src/storage/sqlite/attachments.rs
+++ b/server/src/storage/sqlite/attachments.rs
@@ -236,7 +236,7 @@ mod tests {
             .await
             .unwrap();
 
-        s.associate_attachments(&[att.id.clone()], &msg1.id, &user.id)
+        s.associate_attachments(std::slice::from_ref(&att.id), &msg1.id, &user.id)
             .await
             .unwrap();
 

--- a/server/src/storage/sqlite/threads.rs
+++ b/server/src/storage/sqlite/threads.rs
@@ -226,7 +226,7 @@ mod tests {
         let thread = s.create_thread(&cid, &mid, &uid).await.unwrap();
         let m1 = s.create_message(&cid, &uid, "reply", Some(&thread.id)).await.unwrap();
 
-        let summaries = s.list_thread_summaries(&[mid.clone()]).await.unwrap();
+        let summaries = s.list_thread_summaries(std::slice::from_ref(&mid)).await.unwrap();
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].thread_id, thread.id);
         assert_eq!(summaries[0].reply_count, 1);


### PR DESCRIPTION
Closes #85

## Summary
Adds the `decentcom-sdk` crate at `sdk/rust/`, giving any Rust application
a typed, async entry point into the decentcom protocol — identity
management, challenge-response auth, typed REST wrappers for every
server module, and a low-level WebSocket gateway client with automatic
heartbeat handling.

## Changes
- New workspace member `decentcom-sdk` with:
  - `identity` — BIP39 generation/parsing, Ed25519 key derivation,
    base58 pubkey encoding, base64 signature output.
  - `rest` — session-aware `Client` with per-module APIs for channels,
    messages, members, roles, profiles, invites, threads, reactions,
    and attachments (REST read path; multipart upload deferred per the
    resolved design question).
  - `rest::models` — dedicated wire types mirroring the server's JSON
    shapes, keeping `shared/` focused on pure cross-boundary types.
  - `gateway` — `tokio-tungstenite`-backed `GatewayClient` with auto
    heartbeat ACK, typed command helpers, and a decoded event stream.
- Identity unit tests + wiremock-backed REST integration tests.
- Fixes two pre-existing `clippy::cloned_ref_to_slice_refs` warnings
  that surfaced with a recent toolchain bump.

## Design decisions (issue open questions)
- **`shared/` vs SDK:** keep `shared/` for pure wire types; SDK owns
  the protocol logic and its own request/response wrappers.
- **Attachment uploads:** ship the REST read path now; multipart
  upload helper will be added in a follow-up.

## Testing
- All existing tests pass (160 total across workspace).
- New: 8 identity + gateway unit tests in `sdk/rust/src/`.
- New: 10 wiremock integration tests in `sdk/rust/tests/rest.rs` covering
  auth flow, bearer injection, JSON bodies, query params, anonymous
  requests, 204 responses, and parsed API errors.
- `cargo test --workspace`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.

Integration tests against a live server are deferred to the Bot SDK
(#76) work where a running instance is part of the default harness.