### PR TITLE
fix: resolve all TypeScript build errors

### DIFF
--- a/client/src/api/channels.ts
+++ b/client/src/api/channels.ts
@@ -1,4 +1,6 @@
 import { apiRequest } from "../services/api";
+import type { Attachment } from "./media";
+import type { ReactionSummary } from "./reactions";
 
 export interface Channel {
   id: string;
@@ -6,6 +8,31 @@ export interface Channel {
   category: string | null;
   position: number;
   type: string;
+}
+
+export interface ThreadSummary {
+  thread_id: string;
+  reply_count: number;
+  last_reply_at: string | null;
+  last_reply_author_id: string | null;
+}
+
+export interface Message {
+  id: string;
+  channel_id: string;
+  author_id: string;
+  content: string;
+  created_at: string;
+  edited_at: string | null;
+  deleted: boolean;
+  attachments: Attachment[];
+  reactions: ReactionSummary[];
+  thread: ThreadSummary | null;
+}
+
+export interface MessagePage {
+  messages: Message[];
+  has_more: boolean;
 }
 
 export interface CreateChannelRequest {

--- a/client/src/api/threads.ts
+++ b/client/src/api/threads.ts
@@ -1,5 +1,6 @@
 import { apiRequest } from "../services/api";
 import type { Message, MessagePage } from "./channels";
+export type { Message, MessagePage };
 
 export interface CreateThreadResponse {
   thread_id: string;

--- a/client/src/components/layout/ChannelSidebar.tsx
+++ b/client/src/components/layout/ChannelSidebar.tsx
@@ -10,7 +10,7 @@ import { StatusIndicator } from "../connection/StatusIndicator";
 interface ChannelSidebarProps {
   channels: Channel[];
   currentChannelId: string | null;
-  status: "connecting" | "connected" | "disconnected";
+  status: "connecting" | "connected" | "disconnected" | "reconnecting";
   onSelectChannel: (id: string) => void;
 }
 

--- a/client/src/components/members/MemberContextMenu.test.tsx
+++ b/client/src/components/members/MemberContextMenu.test.tsx
@@ -26,6 +26,7 @@ const baseMember: Member = {
   pubkey: "pk1",
   display_name: "Alice",
   avatar_hash: null,
+  is_bot: false,
   joined_at: "2025-01-01T00:00:00Z",
   roles: [],
 };

--- a/client/src/components/messages/MessageItem.test.tsx
+++ b/client/src/components/messages/MessageItem.test.tsx
@@ -16,6 +16,8 @@ describe("MessageItem", () => {
           edited_at: new Date().toISOString(),
           deleted: false,
           attachments: [],
+          reactions: [],
+          thread: null,
         }}
       />,
     );
@@ -37,6 +39,8 @@ describe("MessageItem", () => {
           edited_at: null,
           deleted: true,
           attachments: [],
+          reactions: [],
+          thread: null,
         }}
       />,
     );

--- a/client/src/hooks/useAccountManager.test.ts
+++ b/client/src/hooks/useAccountManager.test.ts
@@ -148,7 +148,7 @@ describe("useAccountManager", () => {
         }
       });
 
-      expect(caughtError?.message).toMatch(/Backend active account mismatch/);
+      expect((caughtError as Error | null)?.message).toMatch(/Backend active account mismatch/);
 
       // isSwitching should still be cleared on error
       expect(useAccountManagerStore.getState().isSwitching).toBe(false);

--- a/client/src/stores/serverStore.test.ts
+++ b/client/src/stores/serverStore.test.ts
@@ -39,6 +39,8 @@ function makeMsg(id: string, channelId = "ch1"): Message {
     edited_at: null,
     deleted: false,
     attachments: [],
+    reactions: [],
+    thread: null,
   };
 }
 
@@ -55,7 +57,7 @@ describe("serverStore — message ordering & deduplication", () => {
       channels: [],
       currentChannelId: null,
       roles: [],
-    } as Parameters<typeof useServerStore.setState>[0]);
+    });
   });
 
   it("stale-write race: WS message arriving during in-flight fetch survives in correct position", async () => {

--- a/client/src/stores/serverStore.ts
+++ b/client/src/stores/serverStore.ts
@@ -1,9 +1,7 @@
 import { create } from "zustand";
 
-import type { CreateChannelRequest, UpdateChannelRequest } from "../api/channels";
+import type { Channel, CreateChannelRequest, Message, MessagePage, UpdateChannelRequest } from "../api/channels";
 import * as channelsApi from "../api/channels";
-import type { Attachment } from "../api/media";
-import type { ReactionSummary } from "../api/reactions";
 import type { ChannelPermissionOverride, Role } from "../api/roles";
 import { listRoles } from "../api/roles";
 import { ApiError, apiRequest } from "../services/api";
@@ -13,41 +11,10 @@ import { useMembersStore } from "./members";
 import { joinServer } from "../api/members";
 import { useThreadStore } from "./threadStore";
 
-export interface Channel {
-  id: string;
-  name: string;
-  category: string | null;
-  position: number;
-  type: string;
-}
-
-export interface ThreadSummary {
-  thread_id: string;
-  reply_count: number;
-  last_reply_at: string | null;
-  last_reply_author_id: string | null;
-}
-
-export interface Message {
-  id: string;
-  channel_id: string;
-  author_id: string;
-  content: string;
-  created_at: string;
-  edited_at: string | null;
-  deleted: boolean;
-  attachments: Attachment[];
-  reactions: ReactionSummary[];
-  thread: ThreadSummary | null;
-}
+export type { Channel, Message } from "../api/channels";
 
 interface ChannelsResponse {
   channels: Channel[];
-}
-
-interface MessagePage {
-  messages: Message[];
-  has_more: boolean;
 }
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected" | "reconnecting";
@@ -83,6 +50,7 @@ export interface ServerStore {
   serverId: string;
   address: string;
   status: ConnectionStatus;
+  membershipMode: string;
   sessionToken: string | null;
   sessionUserId: string | null;
   channels: Channel[];
@@ -143,6 +111,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
   serverId: "",
   address: "",
   status: "disconnected",
+  membershipMode: "",
   sessionToken: null,
   sessionUserId: null,
   channels: [],
@@ -349,7 +318,7 @@ export const useServerStore = create<ServerStore>((set, get) => ({
 
     try {
       const existing = state.messages[channelId] ?? [];
-      const oldestId = existing.at(-1)?.id;
+      const oldestId = existing[existing.length - 1]?.id;
       const query = oldestId ? `?before=${encodeURIComponent(oldestId)}&limit=50` : "?limit=50";
 
       const page = await apiRequest<MessagePage>(
@@ -587,9 +556,9 @@ export const useServerStore = create<ServerStore>((set, get) => ({
           };
         }
         case "THREAD_CREATE": {
-          const { channel_id, parent_message_id, thread_id } = event.d as {
+          const { channel_id, message_id: parent_message_id, thread_id } = event.d as {
             channel_id: string;
-            parent_message_id: string;
+            message_id: string;
             thread_id: string;
           };
           const existing = state.messages[channel_id] ?? [];


### PR DESCRIPTION
## Summary
- Moves `Message`, `MessagePage`, `ThreadSummary` types to `channels.ts` (where `threads.ts` already expected them) and re-exports them from `threads.ts`; `serverStore.ts` imports from the canonical location
- Adds `membershipMode: string` to `ServerStore` interface (used by `ServerSidebar` but missing from the type)
- Fixes `THREAD_CREATE` gateway event cast (`parent_message_id` → `message_id` to match union type)
- Replaces `Array.at(-1)` with index access (ES2020 lib target doesn't include `Array.prototype.at`)
- Widens `ChannelSidebar` status prop to include `"reconnecting"` (matches full `ConnectionStatus` union)
- Adds missing `is_bot` field to `MemberContextMenu` test fixture
- Adds missing `reactions`/`thread` fields to `Message` fixtures in tests
- Fixes `caughtError` type-narrowing false-positive in `useAccountManager` test
- Removes invalid `Parameters<setState>` cast in `serverStore` test

## Testing
- `tsc`: clean (was 16 errors)
- `pnpm build`: clean
- `pnpm test`: 89/89 pass
- `pnpm lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)