### PR TITLE
fix: graceful SIGTERM shutdown in Docker (#110)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN find shared/src server/src -name "*.rs" -exec touch {} + && \
 # ── Runtime image ────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tini && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/server /usr/local/bin/server
@@ -45,4 +45,4 @@ ENV DECENTCOM_MEDIA=/data/media
 
 EXPOSE 8080
 
-ENTRYPOINT ["server", "--config", "/config/decentcom.toml"]
+ENTRYPOINT ["tini", "--", "server", "--config", "/config/decentcom.toml"]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -156,6 +156,32 @@ fn spawn_invite_cleanup(storage: DynStorage) {
     });
 }
 
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    info!("shutdown signal received, shutting down gracefully");
+}
+
 /// Seed initial data if the server is freshly initialized (no channels exist).
 async fn seed_channels(storage: &DynStorage) -> Result<(), Box<dyn std::error::Error>> {
     let channels = storage.list_channels().await?;
@@ -195,7 +221,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let listener = tokio::net::TcpListener::bind(bind).await?;
     info!(%bind, "listening");
-    axum::serve(listener, app(state)).await?;
+    axum::serve(listener, app(state))
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    info!("server shut down cleanly");
     Ok(())
 }
 


### PR DESCRIPTION
Closes #110

## Summary

- Adds `shutdown_signal()` in `server/src/main.rs` that listens for SIGTERM (Unix) and Ctrl-C via tokio's signal API, then feeds it into `axum::serve(...).with_graceful_shutdown(...)` so the server drains in-flight requests before exiting
- Adds `tini` to the Dockerfile runtime image as PID 1 — forwards signals to child processes and reaps zombies
- Logs `"shutdown signal received, shutting down gracefully"` on signal receipt and `"server shut down cleanly"` after the listener closes

## Changes

- `server/src/main.rs`: `shutdown_signal()` async fn + `.with_graceful_shutdown()` chained onto `axum::serve`
- `Dockerfile`: `tini` installed in runtime apt layer; ENTRYPOINT updated to `["tini", "--", "server", ...]`

## Testing

- All 115 existing server tests pass
- `cargo clippy -- -D warnings`: clean
- Docker shutdown: `docker stop` should complete in < 2 s instead of timing out at 10 s