### PR TITLE
feat: Bot SDK (decentcom-bot) (#76)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "decentcom-bot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "decentcom-sdk",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "shared",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.8.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "decentcom-sdk"
 version = "0.1.0"
 dependencies = [
@@ -4142,6 +4160,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "register-bot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "decentcom-sdk",
+ "tokio",
+]
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "tools/test-setup",
   "tools/sdk-seed",
   "tools/register-bot",
+  "tools/bot-sdk",
 ]
 
 [workspace.package]
@@ -21,6 +22,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.7", features = ["ws"] }
 shared = { path = "shared" }
+decentcom-sdk = { path = "sdk/rust" }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 bs58 = "0.5"
 base64 = "0.22"

--- a/tools/bot-sdk/Cargo.toml
+++ b/tools/bot-sdk/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "decentcom-bot"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Bot SDK for the decentcom protocol — event handlers and REST action helpers."
+
+[dependencies]
+decentcom-sdk = { workspace = true }
+shared = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+anyhow = "1"
+chrono = { workspace = true }
+toml = "0.8"
+futures-util = "0.3"
+
+[dev-dependencies]
+tokio = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/tools/bot-sdk/README.md
+++ b/tools/bot-sdk/README.md
@@ -1,0 +1,142 @@
+# decentcom-bot
+
+Bot SDK for the [decentcom](https://github.com/icub3d/decentcom) protocol.
+
+Wraps the gateway WebSocket and REST API with typed event handlers and action
+helpers so you can build bots in Rust without reimplementing the protocol.
+
+## Quick start
+
+```rust
+use decentcom_bot::{Bot, Context, events::MessageEvent};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    Bot::from_env()?
+        .on_message(handle_message)
+        .run()
+        .await?;
+
+    Ok(())
+}
+
+async fn handle_message(ctx: Context, evt: MessageEvent) -> anyhow::Result<()> {
+    if evt.content.starts_with("!ping") {
+        ctx.reply(&evt, "pong").await?;
+    }
+    Ok(())
+}
+```
+
+Set `BOT_SERVER_URL` and `BOT_MNEMONIC` in your environment, then run:
+
+```
+BOT_SERVER_URL=https://your-server.example.com \
+BOT_MNEMONIC="word1 word2 ... word24" \
+cargo run
+```
+
+## Configuration
+
+Config can come from environment variables, a TOML file, or both (env vars win).
+
+### Environment variables
+
+| Variable          | Required | Description                                     |
+|-------------------|----------|-------------------------------------------------|
+| `BOT_SERVER_URL`  | yes      | Base URL of the decentcom server                |
+| `BOT_MNEMONIC`    | yes      | 24-word BIP39 mnemonic for the bot's identity   |
+| `BOT_DISPLAY_NAME`| no       | Display name shown in the member list           |
+
+### TOML file
+
+```toml
+server_url   = "https://your-server.example.com"
+mnemonic     = "word1 word2 ... word24"
+display_name = "My Bot"      # optional
+```
+
+Load it with `Bot::from_file("bot.toml")`.
+
+## Event handlers
+
+Register handlers via the builder methods. Every handler receives a cloned
+[`Context`] and the typed event payload.
+
+| Method                    | Event payload                              |
+|---------------------------|--------------------------------------------|
+| `on_message`              | New message posted                         |
+| `on_message_update`       | Message edited                             |
+| `on_message_delete`       | Message deleted                            |
+| `on_channel_create`       | Channel created                            |
+| `on_channel_update`       | Channel updated                            |
+| `on_channel_delete`       | Channel deleted                            |
+| `on_role_create`          | Role created                               |
+| `on_role_update`          | Role updated                               |
+| `on_role_delete`          | Role deleted                               |
+| `on_member_role_add`      | Role added to a member                     |
+| `on_member_role_remove`   | Role removed from a member                 |
+| `on_member_join`          | Member joined the server                   |
+| `on_member_leave`         | Member left the server                     |
+| `on_member_kick`          | Member was kicked                          |
+| `on_member_ban`           | Member was banned                          |
+| `on_member_update`        | Member profile updated                     |
+| `on_reaction_add`         | Reaction added to a message                |
+| `on_reaction_remove`      | Reaction removed from a message            |
+| `on_thread_create`        | Thread created                             |
+| `on_thread_message_create`| Reply posted to a thread                   |
+| `on_thread_update`        | Thread updated (reply count etc.)          |
+
+## Context — REST actions
+
+`Context` is the handle your handlers use to interact with the server.
+
+```rust
+// Send a message
+ctx.send(channel_id, "Hello!").await?;
+
+// Reply in the same channel as the incoming message
+ctx.reply(&evt, "pong").await?;
+
+// Edit a message (bot must be the author)
+ctx.edit_message(channel_id, message_id, "updated text").await?;
+
+// Delete a message
+ctx.delete_message(channel_id, message_id).await?;
+
+// Kick a member (by pubkey)
+ctx.kick(pubkey).await?;
+
+// Ban a member
+ctx.ban(pubkey, Some("reason".to_string())).await?;
+
+// Access the full SDK client for anything else
+let members = ctx.sdk().members().list().await?;
+```
+
+## Authentication
+
+The bot uses the same Ed25519 challenge-response flow as human users, with an
+`is_bot: true` claim bound into the signed challenge. The server will queue the
+bot as pending until an admin approves it via the admin panel or API.
+
+The bot's Ed25519 keypair is derived deterministically from its BIP39 mnemonic.
+Keep the mnemonic secret — it is the bot's identity.
+
+## Reconnect behavior
+
+`Bot::run()` loops forever. On any gateway disconnect it waits with exponential
+back-off (1 s → 2 s → 4 s → … → 64 s cap) then reconnects and re-authenticates.
+
+## Logging
+
+`decentcom-bot` uses the [`tracing`](https://docs.rs/tracing) crate. Add a
+subscriber in `main()`:
+
+```rust
+tracing_subscriber::fmt::init();
+```
+
+Or configure it however suits your deployment (JSON output, log levels, etc.).

--- a/tools/bot-sdk/src/bot.rs
+++ b/tools/bot-sdk/src/bot.rs
@@ -1,0 +1,437 @@
+use std::future::Future;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use decentcom_sdk::identity::Identity;
+use decentcom_sdk::rest::Client;
+use tracing::{debug, error, info, warn};
+
+use crate::config::Config;
+use crate::context::Context;
+use crate::error::{Error, Result};
+use shared::gateway::{ReactionEventData, ThreadEventData, ThreadUpdateData};
+
+use crate::events::{
+    ChannelDeleteEvent, ChannelEvent, Event, MemberEvent, MemberModEvent, MemberRoleEvent,
+    MessageDeleteEvent, MessageEvent, RoleDeleteEvent, RoleEvent,
+};
+
+// ── Handler type aliases ───────────────────────────────────────────────────
+
+macro_rules! handler_type {
+    ($name:ident, $evt:ty) => {
+        type $name = Arc<
+            dyn Fn(Context, $evt) -> std::pin::Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>
+                + Send
+                + Sync,
+        >;
+    };
+}
+
+handler_type!(MessageHandler, MessageEvent);
+handler_type!(MessageDeleteHandler, MessageDeleteEvent);
+handler_type!(ChannelHandler, ChannelEvent);
+handler_type!(ChannelDeleteHandler, ChannelDeleteEvent);
+handler_type!(RoleHandler, RoleEvent);
+handler_type!(RoleDeleteHandler, RoleDeleteEvent);
+handler_type!(MemberRoleHandler, MemberRoleEvent);
+handler_type!(MemberHandler, MemberEvent);
+handler_type!(MemberModHandler, MemberModEvent);
+handler_type!(ReactionHandler, ReactionEventData);
+handler_type!(ThreadHandler, ThreadEventData);
+handler_type!(ThreadUpdateHandler, ThreadUpdateData);
+
+#[allow(clippy::type_complexity)]
+fn wrap<F, Fut, E>(f: F) -> Arc<dyn Fn(Context, E) -> std::pin::Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> + Send + Sync>
+where
+    F: Fn(Context, E) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    E: 'static,
+{
+    Arc::new(move |ctx, evt| Box::pin(f(ctx, evt)))
+}
+
+/// Reconnect back-off: starts at 1 s, doubles each attempt, caps at 64 s.
+fn backoff(attempt: u32) -> Duration {
+    let secs = 2u64.pow(attempt).min(64);
+    Duration::from_secs(secs)
+}
+
+/// The main bot builder and runner.
+///
+/// Register event handlers via the `on_*` methods then call [`Bot::run`].
+pub struct Bot {
+    config: Config,
+    on_message: Option<MessageHandler>,
+    on_message_update: Option<MessageHandler>,
+    on_message_delete: Option<MessageDeleteHandler>,
+    on_channel_create: Option<ChannelHandler>,
+    on_channel_update: Option<ChannelHandler>,
+    on_channel_delete: Option<ChannelDeleteHandler>,
+    on_role_create: Option<RoleHandler>,
+    on_role_update: Option<RoleHandler>,
+    on_role_delete: Option<RoleDeleteHandler>,
+    on_member_role_add: Option<MemberRoleHandler>,
+    on_member_role_remove: Option<MemberRoleHandler>,
+    on_member_join: Option<MemberHandler>,
+    on_member_leave: Option<MemberHandler>,
+    on_member_kick: Option<MemberModHandler>,
+    on_member_ban: Option<MemberModHandler>,
+    on_member_update: Option<MemberHandler>,
+    on_reaction_add: Option<ReactionHandler>,
+    on_reaction_remove: Option<ReactionHandler>,
+    on_thread_create: Option<ThreadHandler>,
+    on_thread_message_create: Option<ThreadHandler>,
+    on_thread_update: Option<ThreadUpdateHandler>,
+}
+
+impl Bot {
+    /// Create a bot from environment variables (`BOT_SERVER_URL`, `BOT_MNEMONIC`).
+    pub fn from_env() -> Result<Self> {
+        Self::with_config(Config::from_env()?)
+    }
+
+    /// Create a bot from a TOML config file, with env var overrides.
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
+        Self::with_config(Config::from_file(path)?)
+    }
+
+    /// Create a bot with an explicit [`Config`].
+    pub fn with_config(config: Config) -> Result<Self> {
+        Ok(Self {
+            config,
+            on_message: None,
+            on_message_update: None,
+            on_message_delete: None,
+            on_channel_create: None,
+            on_channel_update: None,
+            on_channel_delete: None,
+            on_role_create: None,
+            on_role_update: None,
+            on_role_delete: None,
+            on_member_role_add: None,
+            on_member_role_remove: None,
+            on_member_join: None,
+            on_member_leave: None,
+            on_member_kick: None,
+            on_member_ban: None,
+            on_member_update: None,
+            on_reaction_add: None,
+            on_reaction_remove: None,
+            on_thread_create: None,
+            on_thread_message_create: None,
+            on_thread_update: None,
+        })
+    }
+
+    // ── Handler registration ───────────────────────────────────────────────
+
+    pub fn on_message<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MessageEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_message = Some(wrap(f)); self
+    }
+
+    pub fn on_message_update<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MessageEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_message_update = Some(wrap(f)); self
+    }
+
+    pub fn on_message_delete<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MessageDeleteEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_message_delete = Some(wrap(f)); self
+    }
+
+    pub fn on_channel_create<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, ChannelEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_channel_create = Some(wrap(f)); self
+    }
+
+    pub fn on_channel_update<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, ChannelEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_channel_update = Some(wrap(f)); self
+    }
+
+    pub fn on_channel_delete<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, ChannelDeleteEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_channel_delete = Some(wrap(f)); self
+    }
+
+    pub fn on_role_create<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, RoleEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_role_create = Some(wrap(f)); self
+    }
+
+    pub fn on_role_update<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, RoleEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_role_update = Some(wrap(f)); self
+    }
+
+    pub fn on_role_delete<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, RoleDeleteEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_role_delete = Some(wrap(f)); self
+    }
+
+    pub fn on_member_role_add<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MemberRoleEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_member_role_add = Some(wrap(f)); self
+    }
+
+    pub fn on_member_role_remove<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MemberRoleEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_member_role_remove = Some(wrap(f)); self
+    }
+
+    pub fn on_member_join<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MemberEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_member_join = Some(wrap(f)); self
+    }
+
+    pub fn on_member_leave<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MemberEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_member_leave = Some(wrap(f)); self
+    }
+
+    pub fn on_member_kick<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MemberModEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_member_kick = Some(wrap(f)); self
+    }
+
+    pub fn on_member_ban<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MemberModEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_member_ban = Some(wrap(f)); self
+    }
+
+    pub fn on_member_update<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, MemberEvent) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_member_update = Some(wrap(f)); self
+    }
+
+    pub fn on_reaction_add<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, ReactionEventData) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_reaction_add = Some(wrap(f)); self
+    }
+
+    pub fn on_reaction_remove<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, ReactionEventData) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_reaction_remove = Some(wrap(f)); self
+    }
+
+    pub fn on_thread_create<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, ThreadEventData) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_thread_create = Some(wrap(f)); self
+    }
+
+    pub fn on_thread_message_create<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, ThreadEventData) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_thread_message_create = Some(wrap(f)); self
+    }
+
+    pub fn on_thread_update<F, Fut>(mut self, f: F) -> Self
+    where F: Fn(Context, ThreadUpdateData) -> Fut + Send + Sync + 'static, Fut: Future<Output = anyhow::Result<()>> + Send + 'static {
+        self.on_thread_update = Some(wrap(f)); self
+    }
+
+    // ── Event loop ─────────────────────────────────────────────────────────
+
+    /// Connect, authenticate, and run the bot's event loop.
+    ///
+    /// Automatically reconnects with exponential back-off on disconnection.
+    /// Returns only on an unrecoverable error (e.g. config error, auth failure
+    /// on the first attempt).
+    pub async fn run(self) -> Result<()> {
+        let config = self.config;
+        let identity = Identity::from_phrase(&config.mnemonic)
+            .map_err(|e| Error::Config(format!("invalid mnemonic: {e}")))?;
+
+        let handlers = Arc::new(Handlers {
+            on_message: self.on_message,
+            on_message_update: self.on_message_update,
+            on_message_delete: self.on_message_delete,
+            on_channel_create: self.on_channel_create,
+            on_channel_update: self.on_channel_update,
+            on_channel_delete: self.on_channel_delete,
+            on_role_create: self.on_role_create,
+            on_role_update: self.on_role_update,
+            on_role_delete: self.on_role_delete,
+            on_member_role_add: self.on_member_role_add,
+            on_member_role_remove: self.on_member_role_remove,
+            on_member_join: self.on_member_join,
+            on_member_leave: self.on_member_leave,
+            on_member_kick: self.on_member_kick,
+            on_member_ban: self.on_member_ban,
+            on_member_update: self.on_member_update,
+            on_reaction_add: self.on_reaction_add,
+            on_reaction_remove: self.on_reaction_remove,
+            on_thread_create: self.on_thread_create,
+            on_thread_message_create: self.on_thread_message_create,
+            on_thread_update: self.on_thread_update,
+        });
+
+        let mut attempt: u32 = 0;
+        loop {
+            match connect_and_run(&config, &identity, handlers.clone()).await {
+                Ok(()) => {
+                    info!("gateway connection closed cleanly");
+                    attempt = 0;
+                }
+                Err(e) => {
+                    warn!("gateway error: {e}");
+                }
+            }
+
+            let delay = backoff(attempt);
+            info!("reconnecting in {}s (attempt {})", delay.as_secs(), attempt + 1);
+            tokio::time::sleep(delay).await;
+            attempt = attempt.saturating_add(1);
+        }
+    }
+}
+
+// ── Connection helper ──────────────────────────────────────────────────────
+
+async fn connect_and_run(
+    config: &Config,
+    identity: &Identity,
+    handlers: Arc<Handlers>,
+) -> Result<()> {
+    let client = Client::new(&config.server_url)?;
+    let resp = client.authenticate_as_bot(identity).await?;
+    info!("authenticated as bot user_id={}", resp.user_id);
+
+    if let Some(name) = &config.display_name {
+        if let Err(e) = client
+            .profiles()
+            .update(&decentcom_sdk::rest::models::UpdateProfileRequest {
+                display_name: Some(name.clone()),
+            })
+            .await
+        {
+            warn!("failed to set display name: {e}");
+        }
+    }
+
+    let ctx = Context::new(client.clone());
+    let mut gw = client.gateway().connect().await?;
+    let hello = gw.wait_for_hello().await?;
+    info!(
+        "connected to server '{}' with {} channels",
+        hello.server_name,
+        hello.channels.len()
+    );
+
+    for ch in &hello.channels {
+        if let Err(e) = gw.subscribe(&ch.id).await {
+            warn!("failed to subscribe to channel {}: {e}", ch.id);
+        }
+    }
+
+    run_event_loop(gw, ctx, handlers).await
+}
+
+// ── Internal handler registry ──────────────────────────────────────────────
+
+struct Handlers {
+    on_message: Option<MessageHandler>,
+    on_message_update: Option<MessageHandler>,
+    on_message_delete: Option<MessageDeleteHandler>,
+    on_channel_create: Option<ChannelHandler>,
+    on_channel_update: Option<ChannelHandler>,
+    on_channel_delete: Option<ChannelDeleteHandler>,
+    on_role_create: Option<RoleHandler>,
+    on_role_update: Option<RoleHandler>,
+    on_role_delete: Option<RoleDeleteHandler>,
+    on_member_role_add: Option<MemberRoleHandler>,
+    on_member_role_remove: Option<MemberRoleHandler>,
+    on_member_join: Option<MemberHandler>,
+    on_member_leave: Option<MemberHandler>,
+    on_member_kick: Option<MemberModHandler>,
+    on_member_ban: Option<MemberModHandler>,
+    on_member_update: Option<MemberHandler>,
+    on_reaction_add: Option<ReactionHandler>,
+    on_reaction_remove: Option<ReactionHandler>,
+    on_thread_create: Option<ThreadHandler>,
+    on_thread_message_create: Option<ThreadHandler>,
+    on_thread_update: Option<ThreadUpdateHandler>,
+}
+
+async fn run_event_loop(
+    mut gw: decentcom_sdk::gateway::GatewayClient,
+    ctx: Context,
+    handlers: Arc<Handlers>,
+) -> Result<()> {
+    loop {
+        let raw = match gw.next_event().await {
+            Some(e) => e,
+            None => return Err(Error::Disconnected),
+        };
+
+        debug!(op = ?raw.op, "received gateway event");
+
+        let event = match Event::from_gateway(&raw) {
+            Ok(Some(e)) => e,
+            Ok(None) => continue, // lifecycle op (Hello/Ready/Heartbeat)
+            Err(e) => {
+                warn!("failed to decode event: {e}");
+                continue;
+            }
+        };
+
+        let ctx = ctx.clone();
+        let handlers = handlers.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = dispatch(ctx, event, &handlers).await {
+                error!("handler error: {e:#}");
+            }
+        });
+    }
+}
+
+macro_rules! dispatch_event {
+    ($ctx:expr, $evt:expr, $handler:expr) => {
+        if let Some(ref h) = $handler {
+            h($ctx, $evt).await?;
+        }
+    };
+}
+
+async fn dispatch(ctx: Context, event: Event, h: &Handlers) -> anyhow::Result<()> {
+    match event {
+        Event::Message(e) => dispatch_event!(ctx, e, h.on_message),
+        Event::MessageUpdate(e) => dispatch_event!(ctx, e, h.on_message_update),
+        Event::MessageDelete(e) => dispatch_event!(ctx, e, h.on_message_delete),
+        Event::ChannelCreate(e) => dispatch_event!(ctx, e, h.on_channel_create),
+        Event::ChannelUpdate(e) => dispatch_event!(ctx, e, h.on_channel_update),
+        Event::ChannelDelete(e) => dispatch_event!(ctx, e, h.on_channel_delete),
+        Event::RoleCreate(e) => dispatch_event!(ctx, e, h.on_role_create),
+        Event::RoleUpdate(e) => dispatch_event!(ctx, e, h.on_role_update),
+        Event::RoleDelete(e) => dispatch_event!(ctx, e, h.on_role_delete),
+        Event::MemberRoleAdd(e) => dispatch_event!(ctx, e, h.on_member_role_add),
+        Event::MemberRoleRemove(e) => dispatch_event!(ctx, e, h.on_member_role_remove),
+        Event::MemberJoin(e) => dispatch_event!(ctx, e, h.on_member_join),
+        Event::MemberLeave(e) => dispatch_event!(ctx, e, h.on_member_leave),
+        Event::MemberKick(e) => dispatch_event!(ctx, e, h.on_member_kick),
+        Event::MemberBan(e) => dispatch_event!(ctx, e, h.on_member_ban),
+        Event::MemberUpdate(e) => dispatch_event!(ctx, e, h.on_member_update),
+        Event::ReactionAdd(e) => dispatch_event!(ctx, e, h.on_reaction_add),
+        Event::ReactionRemove(e) => dispatch_event!(ctx, e, h.on_reaction_remove),
+        Event::ThreadCreate(e) => dispatch_event!(ctx, e, h.on_thread_create),
+        Event::ThreadMessageCreate(e) => dispatch_event!(ctx, e, h.on_thread_message_create),
+        Event::ThreadUpdate(e) => dispatch_event!(ctx, e, h.on_thread_update),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_caps_at_64() {
+        assert_eq!(backoff(0).as_secs(), 1);
+        assert_eq!(backoff(1).as_secs(), 2);
+        assert_eq!(backoff(6).as_secs(), 64);
+        assert_eq!(backoff(10).as_secs(), 64);
+    }
+}

--- a/tools/bot-sdk/src/config.rs
+++ b/tools/bot-sdk/src/config.rs
@@ -1,0 +1,67 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{Error, Result};
+
+/// Bot configuration loaded from a TOML file and/or environment variables.
+///
+/// Environment variables take precedence over TOML file values.
+/// Required fields: `server_url`, `mnemonic`.
+///
+/// Env var names: `BOT_SERVER_URL`, `BOT_MNEMONIC`, `BOT_DISPLAY_NAME`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    /// Base URL of the decentcom server (e.g. `https://decentcom.example.com`).
+    pub server_url: String,
+
+    /// BIP39 mnemonic phrase for the bot's Ed25519 identity.
+    pub mnemonic: String,
+
+    /// Optional display name shown for the bot in the member list.
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+impl Config {
+    /// Load from environment variables only (`BOT_SERVER_URL`, `BOT_MNEMONIC`).
+    pub fn from_env() -> Result<Self> {
+        let server_url = std::env::var("BOT_SERVER_URL")
+            .map_err(|_| Error::Config("BOT_SERVER_URL not set".into()))?;
+        let mnemonic = std::env::var("BOT_MNEMONIC")
+            .map_err(|_| Error::Config("BOT_MNEMONIC not set".into()))?;
+        let display_name = std::env::var("BOT_DISPLAY_NAME").ok();
+
+        Ok(Self { server_url, mnemonic, display_name })
+    }
+
+    /// Load from a TOML file, then override with any env vars that are present.
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
+        let content = std::fs::read_to_string(path.as_ref())
+            .map_err(|e| Error::Config(format!("cannot read config file: {e}")))?;
+        let mut cfg: Config = toml::from_str(&content)
+            .map_err(|e| Error::Config(format!("invalid TOML: {e}")))?;
+
+        // env vars override
+        if let Ok(v) = std::env::var("BOT_SERVER_URL") {
+            cfg.server_url = v;
+        }
+        if let Ok(v) = std::env::var("BOT_MNEMONIC") {
+            cfg.mnemonic = v;
+        }
+        if let Ok(v) = std::env::var("BOT_DISPLAY_NAME") {
+            cfg.display_name = Some(v);
+        }
+
+        Ok(cfg)
+    }
+
+    /// Try loading from a TOML file if it exists, otherwise fall back to env vars.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self> {
+        if path.as_ref().exists() {
+            Self::from_file(path)
+        } else {
+            Self::from_env()
+        }
+    }
+}

--- a/tools/bot-sdk/src/context.rs
+++ b/tools/bot-sdk/src/context.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use decentcom_sdk::rest::{
+    models::{Ban, BanRequest, Message, UpdateMessageRequest},
+    Client,
+};
+
+use crate::error::Result;
+use crate::events::MessageEvent;
+
+/// Handle passed to every event handler that provides REST action helpers.
+///
+/// Cloning is cheap — the inner client is `Arc`-backed.
+#[derive(Clone)]
+pub struct Context {
+    pub(crate) client: Arc<Client>,
+    pub(crate) bot_user_id: String,
+}
+
+impl Context {
+    pub(crate) fn new(client: Client) -> Self {
+        let bot_user_id = client.user_id().unwrap_or_default();
+        Self {
+            client: Arc::new(client),
+            bot_user_id,
+        }
+    }
+
+    // ── Message actions ────────────────────────────────────────────────────
+
+    /// Send a plain-text message to a channel.
+    pub async fn send(&self, channel_id: &str, content: impl Into<String>) -> Result<Message> {
+        Ok(self.client.messages().send_text(channel_id, content).await?)
+    }
+
+    /// Reply to a specific message by sending in the same channel.
+    pub async fn reply(&self, evt: &MessageEvent, content: impl Into<String>) -> Result<Message> {
+        self.send(&evt.channel_id, content).await
+    }
+
+    /// Edit a message. Only messages authored by the bot may be edited.
+    pub async fn edit_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        content: impl Into<String>,
+    ) -> Result<Message> {
+        Ok(self
+            .client
+            .messages()
+            .update(
+                channel_id,
+                message_id,
+                &UpdateMessageRequest { content: content.into() },
+            )
+            .await?)
+    }
+
+    /// Delete a message by ID.
+    pub async fn delete_message(&self, channel_id: &str, message_id: &str) -> Result<()> {
+        Ok(self.client.messages().delete(channel_id, message_id).await?)
+    }
+
+    // ── Moderation actions ─────────────────────────────────────────────────
+
+    /// Kick a member (by pubkey) from the server.
+    pub async fn kick(&self, pubkey: &str) -> Result<()> {
+        Ok(self.client.members().kick(pubkey).await?)
+    }
+
+    /// Permanently ban a member (by pubkey) with an optional reason.
+    pub async fn ban(&self, pubkey: &str, reason: Option<String>) -> Result<Ban> {
+        Ok(self.client.members().ban(pubkey, &BanRequest { reason }).await?)
+    }
+
+    // ── Accessors ──────────────────────────────────────────────────────────
+
+    /// The user ID the bot is authenticated as.
+    pub fn bot_user_id(&self) -> &str {
+        &self.bot_user_id
+    }
+
+    /// Access the underlying SDK client for operations not covered by the
+    /// convenience helpers above.
+    pub fn sdk(&self) -> &Client {
+        &self.client
+    }
+}

--- a/tools/bot-sdk/src/error.rs
+++ b/tools/bot-sdk/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("SDK error: {0}")]
+    Sdk(#[from] decentcom_sdk::Error),
+
+    #[error("configuration error: {0}")]
+    Config(String),
+
+    #[error("event handler error: {0}")]
+    Handler(#[from] anyhow::Error),
+
+    #[error("gateway disconnected")]
+    Disconnected,
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/tools/bot-sdk/src/events.rs
+++ b/tools/bot-sdk/src/events.rs
@@ -1,0 +1,241 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use shared::gateway::{
+    Op, ReactionEventData, ThreadEventData, ThreadUpdateData,
+};
+
+use decentcom_sdk::gateway::GatewayEvent;
+use crate::error::Result;
+
+// ── Per-op payload types ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageEvent {
+    pub id: String,
+    pub channel_id: String,
+    pub author_id: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub edited_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageDeleteEvent {
+    pub id: String,
+    pub channel_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChannelEvent {
+    pub id: String,
+    pub name: String,
+    pub topic: Option<String>,
+    pub category: Option<String>,
+    pub position: i32,
+    #[serde(rename = "type")]
+    pub channel_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChannelDeleteEvent {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoleEvent {
+    pub id: String,
+    pub name: String,
+    pub color: Option<String>,
+    pub permissions: i64,
+    pub position: i32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoleDeleteEvent {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MemberRoleEvent {
+    pub user_id: String,
+    pub role_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MemberEvent {
+    pub user_id: String,
+    pub pubkey: String,
+    pub display_name: Option<String>,
+    pub is_bot: bool,
+    pub joined_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MemberModEvent {
+    pub user_id: String,
+    pub pubkey: String,
+    pub reason: Option<String>,
+}
+
+/// A fully-decoded, typed gateway event.
+#[derive(Debug, Clone)]
+pub enum Event {
+    Message(MessageEvent),
+    MessageUpdate(MessageEvent),
+    MessageDelete(MessageDeleteEvent),
+    ChannelCreate(ChannelEvent),
+    ChannelUpdate(ChannelEvent),
+    ChannelDelete(ChannelDeleteEvent),
+    RoleCreate(RoleEvent),
+    RoleUpdate(RoleEvent),
+    RoleDelete(RoleDeleteEvent),
+    MemberRoleAdd(MemberRoleEvent),
+    MemberRoleRemove(MemberRoleEvent),
+    MemberJoin(MemberEvent),
+    MemberLeave(MemberEvent),
+    MemberKick(MemberModEvent),
+    MemberBan(MemberModEvent),
+    MemberUpdate(MemberEvent),
+    ReactionAdd(ReactionEventData),
+    ReactionRemove(ReactionEventData),
+    ThreadCreate(ThreadEventData),
+    ThreadMessageCreate(ThreadEventData),
+    ThreadUpdate(ThreadUpdateData),
+}
+
+impl Event {
+    /// Decode a raw [`GatewayEvent`] from the SDK into a typed [`Event`].
+    pub fn from_gateway(raw: &GatewayEvent) -> Result<Option<Event>> {
+        let ev = match raw.op {
+            Op::MessageCreate => Event::Message(raw.decode()?),
+            Op::MessageUpdate => Event::MessageUpdate(raw.decode()?),
+            Op::MessageDelete => Event::MessageDelete(raw.decode()?),
+            Op::ChannelCreate => Event::ChannelCreate(raw.decode()?),
+            Op::ChannelUpdate => Event::ChannelUpdate(raw.decode()?),
+            Op::ChannelDelete => Event::ChannelDelete(raw.decode()?),
+            Op::RoleCreate => Event::RoleCreate(raw.decode()?),
+            Op::RoleUpdate => Event::RoleUpdate(raw.decode()?),
+            Op::RoleDelete => Event::RoleDelete(raw.decode()?),
+            Op::MemberRoleAdd => Event::MemberRoleAdd(raw.decode()?),
+            Op::MemberRoleRemove => Event::MemberRoleRemove(raw.decode()?),
+            Op::MemberJoin => Event::MemberJoin(raw.decode()?),
+            Op::MemberLeave => Event::MemberLeave(raw.decode()?),
+            Op::MemberKick => Event::MemberKick(raw.decode()?),
+            Op::MemberBan => Event::MemberBan(raw.decode()?),
+            Op::MemberUpdate => Event::MemberUpdate(raw.decode()?),
+            Op::ReactionAdd => Event::ReactionAdd(raw.decode()?),
+            Op::ReactionRemove => Event::ReactionRemove(raw.decode()?),
+            Op::ThreadCreate => Event::ThreadCreate(raw.decode()?),
+            Op::ThreadMessageCreate => Event::ThreadMessageCreate(raw.decode()?),
+            Op::ThreadUpdate => Event::ThreadUpdate(raw.decode()?),
+            // These are lifecycle ops handled by the run loop, not dispatched as events.
+            Op::Hello | Op::Ready | Op::Heartbeat => return Ok(None),
+        };
+        Ok(Some(ev))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_raw(op: Op, data: serde_json::Value) -> GatewayEvent {
+        GatewayEvent { op, data, t: 0 }
+    }
+
+    #[test]
+    fn decode_message_create() {
+        let data = json!({
+            "id": "m1",
+            "channel_id": "c1",
+            "author_id": "u1",
+            "content": "hello",
+            "created_at": "2024-01-01T00:00:00Z",
+            "edited_at": null,
+        });
+        let raw = make_raw(Op::MessageCreate, data);
+        let ev = Event::from_gateway(&raw).unwrap().unwrap();
+        if let Event::Message(msg) = ev {
+            assert_eq!(msg.content, "hello");
+            assert_eq!(msg.channel_id, "c1");
+        } else {
+            panic!("expected Event::Message");
+        }
+    }
+
+    #[test]
+    fn decode_member_join() {
+        let data = json!({
+            "user_id": "u2",
+            "pubkey": "pk",
+            "display_name": null,
+            "is_bot": false,
+            "joined_at": "2024-01-01T00:00:00Z",
+        });
+        let raw = make_raw(Op::MemberJoin, data);
+        let ev = Event::from_gateway(&raw).unwrap().unwrap();
+        assert!(matches!(ev, Event::MemberJoin(_)));
+    }
+
+    #[test]
+    fn decode_member_leave() {
+        let data = json!({
+            "user_id": "u3",
+            "pubkey": "pk",
+            "display_name": null,
+            "is_bot": false,
+            "joined_at": "2024-01-01T00:00:00Z",
+        });
+        let raw = make_raw(Op::MemberLeave, data);
+        let ev = Event::from_gateway(&raw).unwrap().unwrap();
+        assert!(matches!(ev, Event::MemberLeave(_)));
+    }
+
+    #[test]
+    fn hello_returns_none() {
+        let raw = make_raw(Op::Hello, json!({}));
+        let ev = Event::from_gateway(&raw).unwrap();
+        assert!(ev.is_none());
+    }
+
+    #[test]
+    fn heartbeat_returns_none() {
+        let raw = make_raw(Op::Heartbeat, json!({}));
+        let ev = Event::from_gateway(&raw).unwrap();
+        assert!(ev.is_none());
+    }
+
+    #[test]
+    fn decode_reaction_add() {
+        let data = json!({
+            "channel_id": "c1",
+            "message_id": "m1",
+            "user_id": "u1",
+            "emoji": "👍",
+        });
+        let raw = make_raw(Op::ReactionAdd, data);
+        let ev = Event::from_gateway(&raw).unwrap().unwrap();
+        if let Event::ReactionAdd(r) = ev {
+            assert_eq!(r.emoji, "👍");
+        } else {
+            panic!("expected Event::ReactionAdd");
+        }
+    }
+
+    #[test]
+    fn decode_member_kick() {
+        let data = json!({
+            "user_id": "u1",
+            "pubkey": "pk",
+            "reason": "spam",
+        });
+        let raw = make_raw(Op::MemberKick, data);
+        let ev = Event::from_gateway(&raw).unwrap().unwrap();
+        if let Event::MemberKick(m) = ev {
+            assert_eq!(m.reason.as_deref(), Some("spam"));
+        } else {
+            panic!("expected Event::MemberKick");
+        }
+    }
+}

--- a/tools/bot-sdk/src/lib.rs
+++ b/tools/bot-sdk/src/lib.rs
@@ -1,0 +1,39 @@
+//! `decentcom-bot` — Bot SDK for the decentcom protocol.
+//!
+//! Wraps the gateway WebSocket and REST API with typed event handlers and
+//! action helpers so bot authors can build bots without reimplementing the
+//! protocol.
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use decentcom_bot::{Bot, Context, events::MessageEvent};
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     Bot::from_env()?
+//!         .on_message(handle_message)
+//!         .run()
+//!         .await?;
+//!     Ok(())
+//! }
+//!
+//! async fn handle_message(ctx: Context, evt: MessageEvent) -> anyhow::Result<()> {
+//!     if evt.content.starts_with("!ping") {
+//!         ctx.reply(&evt, "pong").await?;
+//!     }
+//!     Ok(())
+//! }
+//! ```
+
+pub mod bot;
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod events;
+
+pub use bot::Bot;
+pub use config::Config;
+pub use context::Context;
+pub use error::{Error, Result};
+pub use events::{Event, MessageEvent};


### PR DESCRIPTION
Closes #76

## Summary
- New Rust crate `decentcom-bot` at `tools/bot-sdk/` added to the workspace.
- Async event loop driven by the gateway WebSocket with handler dispatch for every `Op` code.
- Typed event payloads for messages, members, channels, roles, reactions, and threads.
- `Bot` builder with `on_*` methods for all event types.
- `Context` REST action helpers: `send`, `reply`, `edit_message`, `delete_message`, `kick`, `ban`.
- Config loading from env vars (`BOT_SERVER_URL`, `BOT_MNEMONIC`, `BOT_DISPLAY_NAME`) and TOML file.
- Automatic reconnect with exponential back-off (1 s → 64 s cap).
- Structured logging via `tracing`.
- Error types via `thiserror`.
- README with minimal example, config table, and full event/action reference.

## Changes
- `Cargo.toml` — added `tools/bot-sdk` workspace member and `decentcom-sdk` workspace dep.
- `tools/bot-sdk/Cargo.toml` — crate manifest.
- `tools/bot-sdk/src/lib.rs` — crate root with doc example.
- `tools/bot-sdk/src/bot.rs` — `Bot` builder, `run()` event loop, reconnect logic.
- `tools/bot-sdk/src/config.rs` — `Config` with env + TOML loading.
- `tools/bot-sdk/src/context.rs` — `Context` REST action helpers.
- `tools/bot-sdk/src/error.rs` — `Error` / `Result` types.
- `tools/bot-sdk/src/events.rs` — typed event payloads and `Event::from_gateway`.
- `tools/bot-sdk/README.md` — usage guide and API reference.

## Testing
- 8 unit tests pass: event deserialization for all major op types, backoff math.
- Doc-test for the quick-start example compiles.
- `cargo clippy -p decentcom-bot -- -D warnings`: clean.
- Integration test (bot connects to running dev server) is a remaining open item tracked in the issue.

## Notes
- `timeout` moderation action is not implemented: no server-side endpoint exists yet. The issue lists it alongside kick/ban; I've omitted it rather than ship a no-op stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)