### PR TITLE
feat: Reference bots — welcomebot, modbot, auditbot (#77)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "chrono",
  "decentcom-sdk",
  "futures-util",
+ "hex",
  "serde",
  "serde_json",
  "shared",
@@ -1240,6 +1241,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "decentcom-bot",
+ "decentcom-sdk",
  "serde",
  "tokio",
  "toml 0.8.2",
@@ -2744,6 +2746,15 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "join-user"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "decentcom-sdk",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "decentcom-auditbot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "decentcom-bot",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml 0.8.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "decentcom-bot"
 version = "0.1.0"
 dependencies = [
@@ -1176,6 +1192,20 @@ dependencies = [
  "serde_json",
  "shared",
  "thiserror 2.0.18",
+ "tokio",
+ "toml 0.8.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "decentcom-modbot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "decentcom-bot",
+ "serde",
  "tokio",
  "toml 0.8.2",
  "tracing",
@@ -1202,6 +1232,19 @@ dependencies = [
  "tokio-tungstenite",
  "url",
  "wiremock",
+]
+
+[[package]]
+name = "decentcom-welcomebot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "decentcom-bot",
+ "serde",
+ "tokio",
+ "toml 0.8.2",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ members = [
   "tools/sdk-seed",
   "tools/register-bot",
   "tools/bot-sdk",
+  "tools/bots/welcomebot",
+  "tools/bots/modbot",
+  "tools/bots/auditbot",
 ]
 
 [workspace.package]
@@ -23,6 +26,7 @@ tokio = { version = "1", features = ["full"] }
 axum = { version = "0.7", features = ["ws"] }
 shared = { path = "shared" }
 decentcom-sdk = { path = "sdk/rust" }
+decentcom-bot = { path = "tools/bot-sdk" }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 bs58 = "0.5"
 base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "tools/bots/welcomebot",
   "tools/bots/modbot",
   "tools/bots/auditbot",
+  "tools/join-user",
 ]
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help clean setup dev servers client clean-identity seed build test lint
+.PHONY: help clean setup dev servers client clean-identity seed test-welcome build test lint
 
 # `seed` is a one-shot process — let overmind treat its clean exit as success
 # instead of tearing the whole session down.
@@ -31,6 +31,9 @@ servers: ## Start only the 3 test servers (no client, no seed)
 
 seed: ## Run the SDK-based seeder against already-running servers
 	cargo run -q --bin sdk-seed
+
+test-welcome: ## Join the Open Server as a fresh user to trigger the welcomebot
+	cargo run -q --bin join-user http://localhost:8081 "Test User"
 
 client: ## Start only the Tauri client dev server
 	cd client && pnpm tauri dev

--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,5 @@ open: cargo watch -i client -p server -x "run -p server -- --config test-configs
 private: cargo watch -i client -p server -x "run -p server -- --config test-configs/private.toml"
 strict: cargo watch -i client -p server -x "run -p server -- --config test-configs/strict.toml"
 seed: cargo run -q --bin sdk-seed
+welcomebot: WELCOMEBOT_CONFIG=test-configs/welcomebot.toml cargo run -q --bin welcomebot
 client: cd client && pnpm tauri dev

--- a/test-configs/welcomebot.toml
+++ b/test-configs/welcomebot.toml
@@ -1,0 +1,9 @@
+server_url    = "http://localhost:8081"
+# bot-alpha identity: derived from the test seed [0x10; 32] used by sdk-seed.
+# This bot is auto-approved on the Open Server when sdk-seed runs.
+seed_hex      = "1010101010101010101010101010101010101010101010101010101010101010"
+display_name  = "WelcomeBot"
+
+welcome_channel  = "general"
+welcome_template = "👋 Welcome, **{display_name}**! Glad to have you on the Open Server."
+rules_message    = "Check out #announcements for server rules."

--- a/tools/bot-sdk/Cargo.toml
+++ b/tools/bot-sdk/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = "1"
 chrono = { workspace = true }
+hex = { workspace = true }
 toml = "0.8"
 futures-util = "0.3"
 

--- a/tools/bot-sdk/src/bot.rs
+++ b/tools/bot-sdk/src/bot.rs
@@ -241,8 +241,17 @@ impl Bot {
     /// on the first attempt).
     pub async fn run(self) -> Result<()> {
         let config = self.config;
-        let identity = Identity::from_phrase(&config.mnemonic)
-            .map_err(|e| Error::Config(format!("invalid mnemonic: {e}")))?;
+        let identity = if let Some(hex) = &config.seed_hex {
+            let bytes = hex::decode(hex)
+                .map_err(|e| Error::Config(format!("invalid seed_hex: {e}")))?;
+            let arr: [u8; 32] = bytes
+                .try_into()
+                .map_err(|_| Error::Config("seed_hex must be exactly 64 hex chars (32 bytes)".into()))?;
+            Identity::from_seed(&arr)
+        } else {
+            Identity::from_phrase(&config.mnemonic)
+                .map_err(|e| Error::Config(format!("invalid mnemonic: {e}")))?
+        };
 
         let handlers = Arc::new(Handlers {
             on_message: self.on_message,

--- a/tools/bot-sdk/src/config.rs
+++ b/tools/bot-sdk/src/config.rs
@@ -7,16 +7,24 @@ use crate::error::{Error, Result};
 /// Bot configuration loaded from a TOML file and/or environment variables.
 ///
 /// Environment variables take precedence over TOML file values.
-/// Required fields: `server_url`, `mnemonic`.
+/// Required: `server_url`, and either `mnemonic` or `seed_hex`.
 ///
-/// Env var names: `BOT_SERVER_URL`, `BOT_MNEMONIC`, `BOT_DISPLAY_NAME`.
-#[derive(Debug, Clone, Deserialize)]
+/// Env var names: `BOT_SERVER_URL`, `BOT_MNEMONIC`, `BOT_SEED_HEX`, `BOT_DISPLAY_NAME`.
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     /// Base URL of the decentcom server (e.g. `https://decentcom.example.com`).
     pub server_url: String,
 
     /// BIP39 mnemonic phrase for the bot's Ed25519 identity.
+    /// Mutually exclusive with `seed_hex`.
+    #[serde(default)]
     pub mnemonic: String,
+
+    /// Raw 32-byte Ed25519 seed encoded as 64 hex characters.
+    /// Takes precedence over `mnemonic` when both are set.
+    /// Use this to reuse test identities derived directly from seed bytes.
+    #[serde(default)]
+    pub seed_hex: Option<String>,
 
     /// Optional display name shown for the bot in the member list.
     #[serde(default)]
@@ -24,15 +32,19 @@ pub struct Config {
 }
 
 impl Config {
-    /// Load from environment variables only (`BOT_SERVER_URL`, `BOT_MNEMONIC`).
+    /// Load from environment variables only (`BOT_SERVER_URL`, `BOT_MNEMONIC` or `BOT_SEED_HEX`).
     pub fn from_env() -> Result<Self> {
         let server_url = std::env::var("BOT_SERVER_URL")
             .map_err(|_| Error::Config("BOT_SERVER_URL not set".into()))?;
-        let mnemonic = std::env::var("BOT_MNEMONIC")
-            .map_err(|_| Error::Config("BOT_MNEMONIC not set".into()))?;
+        let mnemonic = std::env::var("BOT_MNEMONIC").unwrap_or_default();
+        let seed_hex = std::env::var("BOT_SEED_HEX").ok();
         let display_name = std::env::var("BOT_DISPLAY_NAME").ok();
 
-        Ok(Self { server_url, mnemonic, display_name })
+        if mnemonic.is_empty() && seed_hex.is_none() {
+            return Err(Error::Config("BOT_MNEMONIC or BOT_SEED_HEX must be set".into()));
+        }
+
+        Ok(Self { server_url, mnemonic, seed_hex, display_name })
     }
 
     /// Load from a TOML file, then override with any env vars that are present.
@@ -42,12 +54,14 @@ impl Config {
         let mut cfg: Config = toml::from_str(&content)
             .map_err(|e| Error::Config(format!("invalid TOML: {e}")))?;
 
-        // env vars override
         if let Ok(v) = std::env::var("BOT_SERVER_URL") {
             cfg.server_url = v;
         }
         if let Ok(v) = std::env::var("BOT_MNEMONIC") {
             cfg.mnemonic = v;
+        }
+        if let Ok(v) = std::env::var("BOT_SEED_HEX") {
+            cfg.seed_hex = Some(v);
         }
         if let Ok(v) = std::env::var("BOT_DISPLAY_NAME") {
             cfg.display_name = Some(v);

--- a/tools/bots/auditbot/Cargo.toml
+++ b/tools/bots/auditbot/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "decentcom-auditbot"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Reference audit bot for decentcom — streams moderation events to a file or webhook sink."
+
+[[bin]]
+name = "auditbot"
+path = "src/main.rs"
+
+[dependencies]
+decentcom-bot = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+chrono = { workspace = true }
+anyhow = "1"
+toml = "0.8"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/tools/bots/auditbot/README.md
+++ b/tools/bots/auditbot/README.md
@@ -1,0 +1,90 @@
+# decentcom-auditbot
+
+Streams moderation events to a configurable external sink — either a local
+newline-delimited JSON (NDJSON) file or an HTTP webhook.
+
+## Quick start
+
+```
+cargo build -p decentcom-auditbot
+```
+
+### File sink example (`auditbot.toml`)
+
+```toml
+server_url   = "https://your-server.example.com"
+mnemonic     = "word1 word2 ... word24"
+display_name = "AuditBot"
+sink_type    = "file"
+sink_path    = "/var/log/decentcom/audit.ndjson"
+
+[filter]
+member_kick    = true
+member_ban     = true
+message_delete = true
+member_join    = false
+member_leave   = false
+```
+
+### Webhook sink example
+
+```toml
+server_url = "https://your-server.example.com"
+mnemonic   = "word1 word2 ... word24"
+sink_type  = "webhook"
+sink_url   = "https://hooks.example.com/decentcom-audit"
+```
+
+Run:
+
+```
+./target/debug/auditbot
+```
+
+## Event record format
+
+Each event is a JSON object. Example records:
+
+```json
+{"event":"MEMBER_KICK","timestamp":"2024-01-15T12:00:00Z","user_id":"u1","pubkey":"abc…","reason":"spam"}
+{"event":"MEMBER_BAN","timestamp":"2024-01-15T12:01:00Z","user_id":"u2","pubkey":"def…","reason":null}
+{"event":"MESSAGE_DELETE","timestamp":"2024-01-15T12:02:00Z","message_id":"m3","channel_id":"c1"}
+{"event":"MEMBER_JOIN","timestamp":"2024-01-15T12:03:00Z","user_id":"u4","pubkey":"ghi…","is_bot":false}
+{"event":"MEMBER_LEAVE","timestamp":"2024-01-15T12:04:00Z","user_id":"u5","pubkey":"jkl…"}
+```
+
+## Configuration reference
+
+| Key           | Required | Description                                         |
+|---------------|----------|-----------------------------------------------------|
+| `server_url`  | yes      | Base URL of the decentcom server                    |
+| `mnemonic`    | yes      | 24-word BIP39 mnemonic                              |
+| `display_name`| no       | Name shown in the member list                       |
+| `sink_type`   | yes      | `"file"` or `"webhook"`                             |
+| `sink_path`   | if file  | Path to the NDJSON log file (created if missing)    |
+| `sink_url`    | if webhook | URL to POST events to                              |
+
+### `[filter]`
+
+| Key             | Default | Description                         |
+|-----------------|---------|-------------------------------------|
+| `member_kick`   | `true`  | Log member kick events              |
+| `member_ban`    | `true`  | Log member ban events               |
+| `message_delete`| `true`  | Log message delete events           |
+| `member_join`   | `false` | Log member join events              |
+| `member_leave`  | `false` | Log member leave events             |
+
+### Environment variable overrides
+
+| Variable          | Overrides     |
+|-------------------|---------------|
+| `BOT_SERVER_URL`  | `server_url`  |
+| `BOT_MNEMONIC`    | `mnemonic`    |
+| `BOT_DISPLAY_NAME`| `display_name`|
+| `AUDIT_SINK_PATH` | `sink_path`   |
+| `AUDIT_SINK_URL`  | `sink_url`    |
+
+## Notes
+
+- Webhook failures are logged but do not crash the bot.
+- File writes are serialised with an async lock; concurrent events are safe.

--- a/tools/bots/auditbot/src/config.rs
+++ b/tools/bots/auditbot/src/config.rs
@@ -1,0 +1,84 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SinkType {
+    File,
+    Webhook,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EventFilter {
+    #[serde(default = "yes")]
+    pub member_kick: bool,
+    #[serde(default = "yes")]
+    pub member_ban: bool,
+    #[serde(default = "yes")]
+    pub message_delete: bool,
+    #[serde(default = "no")]
+    pub member_join: bool,
+    #[serde(default = "no")]
+    pub member_leave: bool,
+}
+
+fn yes() -> bool { true }
+fn no() -> bool { false }
+
+impl Default for EventFilter {
+    fn default() -> Self {
+        Self {
+            member_kick: true,
+            member_ban: true,
+            message_delete: true,
+            member_join: false,
+            member_leave: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    pub server_url: String,
+    pub mnemonic: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+
+    /// Sink type: `"file"` or `"webhook"`.
+    pub sink_type: SinkType,
+
+    /// For `sink_type = "file"`: path to the log file (NDJSON).
+    pub sink_path: Option<String>,
+
+    /// For `sink_type = "webhook"`: URL to POST events to.
+    pub sink_url: Option<String>,
+
+    #[serde(default)]
+    pub filter: EventFilter,
+}
+
+impl Config {
+    pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path.as_ref())?;
+        let mut cfg: Config = toml::from_str(&content)?;
+
+        if let Ok(v) = std::env::var("BOT_SERVER_URL") {
+            cfg.server_url = v;
+        }
+        if let Ok(v) = std::env::var("BOT_MNEMONIC") {
+            cfg.mnemonic = v;
+        }
+        if let Ok(v) = std::env::var("BOT_DISPLAY_NAME") {
+            cfg.display_name = Some(v);
+        }
+        if let Ok(v) = std::env::var("AUDIT_SINK_PATH") {
+            cfg.sink_path = Some(v);
+        }
+        if let Ok(v) = std::env::var("AUDIT_SINK_URL") {
+            cfg.sink_url = Some(v);
+        }
+
+        Ok(cfg)
+    }
+}

--- a/tools/bots/auditbot/src/main.rs
+++ b/tools/bots/auditbot/src/main.rs
@@ -22,6 +22,7 @@ async fn main() -> anyhow::Result<()> {
     let bot_cfg = BotConfig {
         server_url: cfg.server_url.clone(),
         mnemonic: cfg.mnemonic.clone(),
+        seed_hex: None,
         display_name: cfg.display_name.clone(),
     };
 

--- a/tools/bots/auditbot/src/main.rs
+++ b/tools/bots/auditbot/src/main.rs
@@ -1,0 +1,128 @@
+mod config;
+mod sink;
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use decentcom_bot::{
+    events::{MemberEvent, MemberModEvent, MessageDeleteEvent},
+    Bot, Config as BotConfig, Context,
+};
+use serde_json::json;
+use tracing::info;
+
+use crate::config::Config;
+use crate::sink::Sink;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cfg = Config::load("auditbot.toml")?;
+    let bot_cfg = BotConfig {
+        server_url: cfg.server_url.clone(),
+        mnemonic: cfg.mnemonic.clone(),
+        display_name: cfg.display_name.clone(),
+    };
+
+    let sink = Arc::new(Sink::from_config(&cfg)?);
+    let cfg = Arc::new(cfg);
+
+    let mut bot = Bot::with_config(bot_cfg)?;
+
+    if cfg.filter.member_kick {
+        let sink = sink.clone();
+        bot = bot.on_member_kick(move |_ctx: Context, evt: MemberModEvent| {
+            let sink = sink.clone();
+            async move {
+                info!(user_id = %evt.user_id, "audit: member kicked");
+                let record = json!({
+                    "event": "MEMBER_KICK",
+                    "timestamp": Utc::now(),
+                    "user_id": evt.user_id,
+                    "pubkey": evt.pubkey,
+                    "reason": evt.reason,
+                });
+                sink.write(&record).await;
+                Ok(())
+            }
+        });
+    }
+
+    if cfg.filter.member_ban {
+        let sink = sink.clone();
+        bot = bot.on_member_ban(move |_ctx: Context, evt: MemberModEvent| {
+            let sink = sink.clone();
+            async move {
+                info!(user_id = %evt.user_id, "audit: member banned");
+                let record = json!({
+                    "event": "MEMBER_BAN",
+                    "timestamp": Utc::now(),
+                    "user_id": evt.user_id,
+                    "pubkey": evt.pubkey,
+                    "reason": evt.reason,
+                });
+                sink.write(&record).await;
+                Ok(())
+            }
+        });
+    }
+
+    if cfg.filter.message_delete {
+        let sink = sink.clone();
+        bot = bot.on_message_delete(move |_ctx: Context, evt: MessageDeleteEvent| {
+            let sink = sink.clone();
+            async move {
+                info!(message_id = %evt.id, "audit: message deleted");
+                let record = json!({
+                    "event": "MESSAGE_DELETE",
+                    "timestamp": Utc::now(),
+                    "message_id": evt.id,
+                    "channel_id": evt.channel_id,
+                });
+                sink.write(&record).await;
+                Ok(())
+            }
+        });
+    }
+
+    if cfg.filter.member_join {
+        let sink = sink.clone();
+        bot = bot.on_member_join(move |_ctx: Context, evt: MemberEvent| {
+            let sink = sink.clone();
+            async move {
+                info!(user_id = %evt.user_id, "audit: member joined");
+                let record = json!({
+                    "event": "MEMBER_JOIN",
+                    "timestamp": Utc::now(),
+                    "user_id": evt.user_id,
+                    "pubkey": evt.pubkey,
+                    "is_bot": evt.is_bot,
+                });
+                sink.write(&record).await;
+                Ok(())
+            }
+        });
+    }
+
+    if cfg.filter.member_leave {
+        let sink = sink.clone();
+        bot = bot.on_member_leave(move |_ctx: Context, evt: MemberEvent| {
+            let sink = sink.clone();
+            async move {
+                info!(user_id = %evt.user_id, "audit: member left");
+                let record = json!({
+                    "event": "MEMBER_LEAVE",
+                    "timestamp": Utc::now(),
+                    "user_id": evt.user_id,
+                    "pubkey": evt.pubkey,
+                });
+                sink.write(&record).await;
+                Ok(())
+            }
+        });
+    }
+
+    bot.run().await?;
+    Ok(())
+}

--- a/tools/bots/auditbot/src/sink.rs
+++ b/tools/bots/auditbot/src/sink.rs
@@ -1,0 +1,118 @@
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use crate::config::{Config, SinkType};
+
+/// Shared, async-safe event sink.
+#[derive(Clone)]
+pub struct Sink {
+    inner: Arc<Inner>,
+}
+
+enum Inner {
+    File {
+        path: String,
+        lock: Mutex<()>,
+    },
+    Webhook {
+        url: String,
+        client: reqwest::Client,
+    },
+}
+
+impl Sink {
+    pub fn from_config(cfg: &Config) -> anyhow::Result<Self> {
+        let inner = match cfg.sink_type {
+            SinkType::File => {
+                let path = cfg
+                    .sink_path
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("sink_path required for file sink"))?;
+                Inner::File {
+                    path,
+                    lock: Mutex::new(()),
+                }
+            }
+            SinkType::Webhook => {
+                let url = cfg
+                    .sink_url
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("sink_url required for webhook sink"))?;
+                let client = reqwest::Client::builder()
+                    .user_agent(concat!("decentcom-auditbot/", env!("CARGO_PKG_VERSION")))
+                    .build()?;
+                Inner::Webhook { url, client }
+            }
+        };
+        Ok(Self { inner: Arc::new(inner) })
+    }
+
+    /// Write a structured event record to the sink.
+    pub async fn write(&self, record: &Value) {
+        match self.inner.as_ref() {
+            Inner::File { path, lock } => {
+                let _guard = lock.lock().await;
+                let line = match serde_json::to_string(record) {
+                    Ok(s) => s + "\n",
+                    Err(e) => {
+                        warn!("failed to serialize audit record: {e}");
+                        return;
+                    }
+                };
+                use std::io::Write;
+                let result = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)
+                    .and_then(|mut f| f.write_all(line.as_bytes()));
+                if let Err(e) = result {
+                    warn!("failed to write audit record to {path}: {e}");
+                }
+            }
+            Inner::Webhook { url, client } => {
+                if let Err(e) = client.post(url).json(record).send().await {
+                    warn!("failed to POST audit record to {url}: {e}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{EventFilter, SinkType};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn file_sink_appends_json_lines() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("auditbot-test-{}.ndjson", std::process::id()));
+        let path_str = path.to_string_lossy().to_string();
+
+        let cfg = Config {
+            server_url: "http://localhost".to_string(),
+            mnemonic: "test".to_string(),
+            display_name: None,
+            sink_type: SinkType::File,
+            sink_path: Some(path_str.clone()),
+            sink_url: None,
+            filter: EventFilter::default(),
+        };
+
+        let sink = Sink::from_config(&cfg).unwrap();
+        sink.write(&json!({"event": "test1"})).await;
+        sink.write(&json!({"event": "test2"})).await;
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("test1"));
+        assert!(lines[1].contains("test2"));
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/tools/bots/modbot/Cargo.toml
+++ b/tools/bots/modbot/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "decentcom-modbot"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Reference moderation bot for decentcom — detects spam patterns and takes configured action."
+
+[[bin]]
+name = "modbot"
+path = "src/main.rs"
+
+[dependencies]
+decentcom-bot = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+chrono = { workspace = true }
+anyhow = "1"
+toml = "0.8"

--- a/tools/bots/modbot/README.md
+++ b/tools/bots/modbot/README.md
@@ -1,0 +1,74 @@
+# decentcom-modbot
+
+Detects spam patterns and takes configurable action (warn / kick / ban).
+
+## Detection rules
+
+| Rule               | Description                                                |
+|--------------------|------------------------------------------------------------|
+| Duplicate messages | Same content sent N times within a sliding window          |
+| Link flood         | More than N `http://`/`https://` links within a window     |
+
+## Quick start
+
+```
+cargo build -p decentcom-modbot
+```
+
+Create `modbot.toml`:
+
+```toml
+server_url   = "https://your-server.example.com"
+mnemonic     = "word1 word2 ... word24"
+display_name = "ModBot"
+
+[detection]
+duplicate_threshold   = 5    # trigger after 5 identical messages …
+duplicate_window_secs = 30   # … within 30 seconds
+link_threshold        = 5    # trigger after 5 links …
+link_window_secs      = 60   # … within 60 seconds
+
+[action]
+on_duplicate    = "warn"    # warn | kick | ban
+on_link_flood   = "kick"
+warn_channel_id = "general" # required if any action is "warn"
+```
+
+Run:
+
+```
+./target/debug/modbot
+```
+
+## Configuration reference
+
+### `[detection]`
+
+| Key                    | Default | Description                                  |
+|------------------------|---------|----------------------------------------------|
+| `duplicate_threshold`  | 5       | Identical-message count to trigger           |
+| `duplicate_window_secs`| 30      | Sliding window for duplicate detection       |
+| `link_threshold`       | 5       | Link count to trigger                        |
+| `link_window_secs`     | 60      | Sliding window for link flood detection      |
+
+### `[action]`
+
+| Key               | Default  | Values              | Description                          |
+|-------------------|----------|---------------------|--------------------------------------|
+| `on_duplicate`    | `"warn"` | warn / kick / ban   | Action on duplicate message rule     |
+| `on_link_flood`   | `"kick"` | warn / kick / ban   | Action on link flood rule            |
+| `warn_channel_id` | —        | channel ID          | Channel for warning messages         |
+
+### Environment variable overrides
+
+| Variable          | Overrides     |
+|-------------------|---------------|
+| `BOT_SERVER_URL`  | `server_url`  |
+| `BOT_MNEMONIC`    | `mnemonic`    |
+| `BOT_DISPLAY_NAME`| `display_name`|
+
+## Notes
+
+- State is in-memory only; restarting the bot resets all counters.
+- The `timeout` action is not available in this release (no server-side endpoint yet).
+- Bot's own messages are never flagged.

--- a/tools/bots/modbot/src/config.rs
+++ b/tools/bots/modbot/src/config.rs
@@ -1,0 +1,116 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Warn,
+    Kick,
+    Ban,
+}
+
+impl Action {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Action::Warn => "warn",
+            Action::Kick => "kick",
+            Action::Ban => "ban",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Detection {
+    /// Number of identical messages within `duplicate_window_secs` to trigger action.
+    #[serde(default = "default_duplicate_threshold")]
+    pub duplicate_threshold: usize,
+
+    /// Sliding window in seconds for duplicate detection.
+    #[serde(default = "default_duplicate_window_secs")]
+    pub duplicate_window_secs: u64,
+
+    /// Number of links (http/https) within `link_window_secs` to trigger action.
+    #[serde(default = "default_link_threshold")]
+    pub link_threshold: usize,
+
+    /// Sliding window in seconds for link flood detection.
+    #[serde(default = "default_link_window_secs")]
+    pub link_window_secs: u64,
+}
+
+fn default_duplicate_threshold() -> usize { 5 }
+fn default_duplicate_window_secs() -> u64 { 30 }
+fn default_link_threshold() -> usize { 5 }
+fn default_link_window_secs() -> u64 { 60 }
+
+impl Default for Detection {
+    fn default() -> Self {
+        Self {
+            duplicate_threshold: default_duplicate_threshold(),
+            duplicate_window_secs: default_duplicate_window_secs(),
+            link_threshold: default_link_threshold(),
+            link_window_secs: default_link_window_secs(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ActionPolicy {
+    /// Action taken when a user hits the duplicate message threshold.
+    #[serde(default = "default_on_duplicate")]
+    pub on_duplicate: Action,
+
+    /// Action taken when a user hits the link flood threshold.
+    #[serde(default = "default_on_link_flood")]
+    pub on_link_flood: Action,
+
+    /// Channel ID where warning messages are posted (for `Action::Warn`).
+    pub warn_channel_id: Option<String>,
+}
+
+fn default_on_duplicate() -> Action { Action::Warn }
+fn default_on_link_flood() -> Action { Action::Kick }
+
+impl Default for ActionPolicy {
+    fn default() -> Self {
+        Self {
+            on_duplicate: default_on_duplicate(),
+            on_link_flood: default_on_link_flood(),
+            warn_channel_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    pub server_url: String,
+    pub mnemonic: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+
+    #[serde(default)]
+    pub detection: Detection,
+
+    #[serde(default)]
+    pub action: ActionPolicy,
+}
+
+impl Config {
+    pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path.as_ref())?;
+        let mut cfg: Config = toml::from_str(&content)?;
+
+        if let Ok(v) = std::env::var("BOT_SERVER_URL") {
+            cfg.server_url = v;
+        }
+        if let Ok(v) = std::env::var("BOT_MNEMONIC") {
+            cfg.mnemonic = v;
+        }
+        if let Ok(v) = std::env::var("BOT_DISPLAY_NAME") {
+            cfg.display_name = Some(v);
+        }
+
+        Ok(cfg)
+    }
+}

--- a/tools/bots/modbot/src/detector.rs
+++ b/tools/bots/modbot/src/detector.rs
@@ -1,0 +1,158 @@
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+/// Records of recent messages and links for a single user.
+#[derive(Default)]
+struct UserRecord {
+    /// Ring buffer of (sent_at, content_hash) for deduplication.
+    recent_messages: VecDeque<(Instant, u64)>,
+    /// Ring buffer of link-post timestamps.
+    recent_links: VecDeque<Instant>,
+}
+
+impl UserRecord {
+    fn prune_messages(&mut self, window: Duration) {
+        let cutoff = Instant::now() - window;
+        while self.recent_messages.front().is_some_and(|(t, _)| *t < cutoff) {
+            self.recent_messages.pop_front();
+        }
+    }
+
+    fn prune_links(&mut self, window: Duration) {
+        let cutoff = Instant::now() - window;
+        while self.recent_links.front().is_some_and(|t| *t < cutoff) {
+            self.recent_links.pop_front();
+        }
+    }
+}
+
+pub struct Detector {
+    state: HashMap<String, UserRecord>,
+    pub duplicate_threshold: usize,
+    pub duplicate_window: Duration,
+    pub link_threshold: usize,
+    pub link_window: Duration,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Violation {
+    DuplicateMessages,
+    LinkFlood,
+}
+
+impl Detector {
+    pub fn new(
+        duplicate_threshold: usize,
+        duplicate_window_secs: u64,
+        link_threshold: usize,
+        link_window_secs: u64,
+    ) -> Self {
+        Self {
+            state: HashMap::new(),
+            duplicate_threshold,
+            duplicate_window: Duration::from_secs(duplicate_window_secs),
+            link_threshold,
+            link_window: Duration::from_secs(link_window_secs),
+        }
+    }
+
+    /// Record a message for `user_id` and return any violations detected.
+    pub fn record_message(&mut self, user_id: &str, content: &str) -> Vec<Violation> {
+        let record = self.state.entry(user_id.to_string()).or_default();
+        let now = Instant::now();
+
+        record.prune_messages(self.duplicate_window);
+        record.prune_links(self.link_window);
+
+        let content_hash = hash_content(content);
+        record.recent_messages.push_back((now, content_hash));
+
+        let link_count = count_links(content);
+        for _ in 0..link_count {
+            record.recent_links.push_back(now);
+        }
+
+        let mut violations = Vec::new();
+
+        // Check duplicate threshold.
+        let dup_count = record
+            .recent_messages
+            .iter()
+            .filter(|(_, h)| *h == content_hash)
+            .count();
+        if dup_count >= self.duplicate_threshold {
+            violations.push(Violation::DuplicateMessages);
+        }
+
+        // Check link flood threshold.
+        if record.recent_links.len() >= self.link_threshold {
+            violations.push(Violation::LinkFlood);
+        }
+
+        violations
+    }
+
+    /// Clear state for a user (e.g. after they've been kicked/banned).
+    pub fn clear_user(&mut self, user_id: &str) {
+        self.state.remove(user_id);
+    }
+}
+
+fn hash_content(content: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    content.to_lowercase().trim().hash(&mut hasher);
+    hasher.finish()
+}
+
+fn count_links(content: &str) -> usize {
+    // Count non-overlapping occurrences of http:// or https://.
+    let lower = content.to_lowercase();
+    lower.matches("http://").count() + lower.matches("https://").count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_detection() {
+        let mut d = Detector::new(3, 30, 5, 60);
+        let uid = "user1";
+        // Two duplicates — no violation yet.
+        assert!(d.record_message(uid, "hello").is_empty());
+        assert!(d.record_message(uid, "hello").is_empty());
+        // Third duplicate — violation.
+        let v = d.record_message(uid, "hello");
+        assert!(v.contains(&Violation::DuplicateMessages));
+    }
+
+    #[test]
+    fn link_flood_detection() {
+        let mut d = Detector::new(5, 30, 3, 60);
+        let uid = "user2";
+        assert!(d.record_message(uid, "check http://a.com").is_empty());
+        assert!(d.record_message(uid, "check http://b.com").is_empty());
+        // Third link triggers flood.
+        let v = d.record_message(uid, "check http://c.com");
+        assert!(v.contains(&Violation::LinkFlood));
+    }
+
+    #[test]
+    fn no_violation_for_varied_messages() {
+        let mut d = Detector::new(5, 30, 5, 60);
+        let uid = "user3";
+        for i in 0..10 {
+            let msg = format!("message {i}");
+            let v = d.record_message(uid, &msg);
+            assert!(v.is_empty(), "unexpected violation at message {i}");
+        }
+    }
+
+    #[test]
+    fn count_links_finds_http_and_https() {
+        assert_eq!(count_links("visit http://a.com and https://b.com"), 2);
+        assert_eq!(count_links("no links here"), 0);
+        assert_eq!(count_links("HTTP://UPPER.COM"), 1);
+    }
+}

--- a/tools/bots/modbot/src/main.rs
+++ b/tools/bots/modbot/src/main.rs
@@ -1,0 +1,120 @@
+mod config;
+mod detector;
+
+use std::sync::Arc;
+
+use decentcom_bot::{events::MessageEvent, Bot, Config as BotConfig, Context};
+use detector::{Detector, Violation};
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+use crate::config::{Action, Config};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cfg = Config::load("modbot.toml")?;
+    let bot_cfg = BotConfig {
+        server_url: cfg.server_url.clone(),
+        mnemonic: cfg.mnemonic.clone(),
+        display_name: cfg.display_name.clone(),
+    };
+
+    let cfg = Arc::new(cfg);
+    let detector = Arc::new(Mutex::new(Detector::new(
+        cfg.detection.duplicate_threshold,
+        cfg.detection.duplicate_window_secs,
+        cfg.detection.link_threshold,
+        cfg.detection.link_window_secs,
+    )));
+
+    Bot::with_config(bot_cfg)?
+        .on_message({
+            let cfg = cfg.clone();
+            let detector = detector.clone();
+            move |ctx, evt| {
+                let cfg = cfg.clone();
+                let detector = detector.clone();
+                async move { handle_message(ctx, evt, &cfg, detector).await }
+            }
+        })
+        .run()
+        .await?;
+
+    Ok(())
+}
+
+async fn handle_message(
+    ctx: Context,
+    evt: MessageEvent,
+    cfg: &Config,
+    detector: Arc<Mutex<Detector>>,
+) -> anyhow::Result<()> {
+    // Ignore bot messages.
+    if evt.author_id == ctx.bot_user_id() {
+        return Ok(());
+    }
+
+    let violations = {
+        let mut d = detector.lock().await;
+        d.record_message(&evt.author_id, &evt.content)
+    };
+
+    for violation in violations {
+        let (action, reason) = match violation {
+            Violation::DuplicateMessages => (
+                &cfg.action.on_duplicate,
+                format!(
+                    "sending duplicate messages ({} times in {}s)",
+                    cfg.detection.duplicate_threshold,
+                    cfg.detection.duplicate_window_secs
+                ),
+            ),
+            Violation::LinkFlood => (
+                &cfg.action.on_link_flood,
+                format!(
+                    "link flood ({} links in {}s)",
+                    cfg.detection.link_threshold,
+                    cfg.detection.link_window_secs
+                ),
+            ),
+        };
+
+        info!(
+            user_id = %evt.author_id,
+            action = action.as_str(),
+            reason = %reason,
+            "modbot action triggered"
+        );
+
+        match action {
+            Action::Warn => {
+                if let Some(ch) = &cfg.action.warn_channel_id {
+                    let msg = format!(
+                        "Warning: <{}> — {}",
+                        evt.author_id, reason
+                    );
+                    if let Err(e) = ctx.send(ch, &msg).await {
+                        warn!("failed to post warning: {e}");
+                    }
+                }
+            }
+            Action::Kick => {
+                // Clear state so a re-join starts fresh.
+                detector.lock().await.clear_user(&evt.author_id);
+                if let Err(e) = ctx.kick(&evt.author_id).await {
+                    warn!("failed to kick {}: {e}", evt.author_id);
+                }
+            }
+            Action::Ban => {
+                detector.lock().await.clear_user(&evt.author_id);
+                if let Err(e) = ctx.ban(&evt.author_id, Some(reason)).await {
+                    warn!("failed to ban {}: {e}", evt.author_id);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/tools/bots/modbot/src/main.rs
+++ b/tools/bots/modbot/src/main.rs
@@ -18,6 +18,7 @@ async fn main() -> anyhow::Result<()> {
     let bot_cfg = BotConfig {
         server_url: cfg.server_url.clone(),
         mnemonic: cfg.mnemonic.clone(),
+        seed_hex: None,
         display_name: cfg.display_name.clone(),
     };
 

--- a/tools/bots/welcomebot/Cargo.toml
+++ b/tools/bots/welcomebot/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "decentcom-welcomebot"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Reference welcomebot for decentcom — greets new members and posts server rules."
+
+[[bin]]
+name = "welcomebot"
+path = "src/main.rs"
+
+[dependencies]
+decentcom-bot = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = "1"
+toml = "0.8"

--- a/tools/bots/welcomebot/Cargo.toml
+++ b/tools/bots/welcomebot/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 decentcom-bot = { workspace = true }
+decentcom-sdk = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/tools/bots/welcomebot/README.md
+++ b/tools/bots/welcomebot/README.md
@@ -1,0 +1,58 @@
+# decentcom-welcomebot
+
+Greets new members in a configured channel and optionally posts server rules.
+
+## Quick start
+
+```
+cargo build -p decentcom-welcomebot
+```
+
+Create `welcomebot.toml`:
+
+```toml
+server_url         = "https://your-server.example.com"
+mnemonic           = "word1 word2 ... word24"
+display_name       = "WelcomeBot"        # optional
+welcome_channel_id = "general"
+welcome_template   = "Welcome, **{display_name}**! Glad to have you here."
+rules_message      = "Please keep it friendly — see #rules for the full list."  # optional
+```
+
+Run:
+
+```
+./target/debug/welcomebot
+```
+
+Or with env vars (override any TOML field):
+
+```
+BOT_SERVER_URL=https://... BOT_MNEMONIC="..." ./welcomebot
+```
+
+## Configuration reference
+
+| Key                  | Required | Default                                           | Description                                               |
+|----------------------|----------|---------------------------------------------------|-----------------------------------------------------------|
+| `server_url`         | yes      | —                                                 | Base URL of the decentcom server                          |
+| `mnemonic`           | yes      | —                                                 | 24-word BIP39 mnemonic for the bot's identity             |
+| `display_name`       | no       | —                                                 | Name shown in the member list                             |
+| `welcome_channel_id` | yes      | —                                                 | Channel where welcome messages are posted                 |
+| `welcome_template`   | no       | `"Welcome, **{display_name}**! Glad to have you here."` | Message template (`{display_name}`, `{pubkey}` supported) |
+| `rules_message`      | no       | —                                                 | Extra message posted after the welcome                    |
+
+### Environment variable overrides
+
+| Variable              | Overrides              |
+|-----------------------|------------------------|
+| `BOT_SERVER_URL`      | `server_url`           |
+| `BOT_MNEMONIC`        | `mnemonic`             |
+| `BOT_DISPLAY_NAME`    | `display_name`         |
+| `WELCOME_CHANNEL_ID`  | `welcome_channel_id`   |
+| `WELCOME_TEMPLATE`    | `welcome_template`     |
+
+## Authentication
+
+The bot needs to be approved by a server admin before it can send messages.
+After first run it will appear in the admin panel's pending-bot queue.

--- a/tools/bots/welcomebot/src/config.rs
+++ b/tools/bots/welcomebot/src/config.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    pub server_url: String,
+    pub mnemonic: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+
+    /// Channel ID where welcome messages are sent.
+    pub welcome_channel_id: String,
+
+    /// Template for the welcome message.
+    /// Supports `{display_name}` and `{pubkey}` placeholders.
+    #[serde(default = "default_welcome_template")]
+    pub welcome_template: String,
+
+    /// Optional additional message posted after the welcome (e.g. server rules).
+    #[serde(default)]
+    pub rules_message: Option<String>,
+}
+
+fn default_welcome_template() -> String {
+    "Welcome, **{display_name}**! Glad to have you here.".to_string()
+}
+
+impl Config {
+    pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path.as_ref())?;
+        let mut cfg: Config = toml::from_str(&content)?;
+
+        if let Ok(v) = std::env::var("BOT_SERVER_URL") {
+            cfg.server_url = v;
+        }
+        if let Ok(v) = std::env::var("BOT_MNEMONIC") {
+            cfg.mnemonic = v;
+        }
+        if let Ok(v) = std::env::var("BOT_DISPLAY_NAME") {
+            cfg.display_name = Some(v);
+        }
+        if let Ok(v) = std::env::var("WELCOME_CHANNEL_ID") {
+            cfg.welcome_channel_id = v;
+        }
+        if let Ok(v) = std::env::var("WELCOME_TEMPLATE") {
+            cfg.welcome_template = v;
+        }
+
+        Ok(cfg)
+    }
+}

--- a/tools/bots/welcomebot/src/config.rs
+++ b/tools/bots/welcomebot/src/config.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub server_url: String,
+    #[serde(default)]
     pub mnemonic: String,
     #[serde(default)]
     pub display_name: Option<String>,

--- a/tools/bots/welcomebot/src/config.rs
+++ b/tools/bots/welcomebot/src/config.rs
@@ -8,9 +8,13 @@ pub struct Config {
     pub mnemonic: String,
     #[serde(default)]
     pub display_name: Option<String>,
+    /// Raw 32-byte Ed25519 seed as 64 hex chars (alternative to mnemonic).
+    #[serde(default)]
+    pub seed_hex: Option<String>,
 
-    /// Channel ID where welcome messages are sent.
-    pub welcome_channel_id: String,
+    /// Channel name *or* channel ID where welcome messages are sent.
+    /// The bot resolves names to IDs at first use via the REST API.
+    pub welcome_channel: String,
 
     /// Template for the welcome message.
     /// Supports `{display_name}` and `{pubkey}` placeholders.
@@ -27,6 +31,9 @@ fn default_welcome_template() -> String {
 }
 
 impl Config {
+    /// Load from `path`, with env var overrides.
+    /// The config path itself is read from the `WELCOMEBOT_CONFIG` env var,
+    /// defaulting to `welcomebot.toml`.
     pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(path.as_ref())?;
         let mut cfg: Config = toml::from_str(&content)?;
@@ -37,16 +44,24 @@ impl Config {
         if let Ok(v) = std::env::var("BOT_MNEMONIC") {
             cfg.mnemonic = v;
         }
+        if let Ok(v) = std::env::var("BOT_SEED_HEX") {
+            cfg.seed_hex = Some(v);
+        }
         if let Ok(v) = std::env::var("BOT_DISPLAY_NAME") {
             cfg.display_name = Some(v);
         }
-        if let Ok(v) = std::env::var("WELCOME_CHANNEL_ID") {
-            cfg.welcome_channel_id = v;
+        if let Ok(v) = std::env::var("WELCOME_CHANNEL") {
+            cfg.welcome_channel = v;
         }
         if let Ok(v) = std::env::var("WELCOME_TEMPLATE") {
             cfg.welcome_template = v;
         }
 
         Ok(cfg)
+    }
+
+    /// Returns the path to load config from: `$WELCOMEBOT_CONFIG` or `welcomebot.toml`.
+    pub fn default_path() -> String {
+        std::env::var("WELCOMEBOT_CONFIG").unwrap_or_else(|_| "welcomebot.toml".to_string())
     }
 }

--- a/tools/bots/welcomebot/src/main.rs
+++ b/tools/bots/welcomebot/src/main.rs
@@ -1,0 +1,73 @@
+mod config;
+
+use std::sync::Arc;
+
+use decentcom_bot::{events::MemberEvent, Bot, Config as BotConfig, Context};
+use tracing::warn;
+
+use crate::config::Config;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cfg = Config::load("welcomebot.toml")?;
+    let bot_cfg = BotConfig {
+        server_url: cfg.server_url.clone(),
+        mnemonic: cfg.mnemonic.clone(),
+        display_name: cfg.display_name.clone(),
+    };
+
+    let cfg = Arc::new(cfg);
+
+    Bot::with_config(bot_cfg)?
+        .on_member_join(move |ctx: Context, evt: MemberEvent| {
+            let cfg = cfg.clone();
+            async move { handle_join(ctx, evt, &cfg).await }
+        })
+        .run()
+        .await?;
+
+    Ok(())
+}
+
+async fn handle_join(ctx: Context, evt: MemberEvent, cfg: &Config) -> anyhow::Result<()> {
+    if evt.is_bot {
+        return Ok(());
+    }
+
+    let display_name = evt
+        .display_name
+        .as_deref()
+        .unwrap_or("new member")
+        .to_string();
+
+    let msg = cfg
+        .welcome_template
+        .replace("{display_name}", &display_name)
+        .replace("{pubkey}", &evt.pubkey);
+
+    if let Err(e) = ctx.send(&cfg.welcome_channel_id, &msg).await {
+        warn!("failed to send welcome message: {e}");
+    }
+
+    if let Some(rules) = &cfg.rules_message {
+        if let Err(e) = ctx.send(&cfg.welcome_channel_id, rules).await {
+            warn!("failed to send rules message: {e}");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn template_interpolation() {
+        let tmpl = "Welcome, **{display_name}**! pubkey={pubkey}";
+        let result = tmpl
+            .replace("{display_name}", "Alice")
+            .replace("{pubkey}", "abc123");
+        assert_eq!(result, "Welcome, **Alice**! pubkey=abc123");
+    }
+}

--- a/tools/bots/welcomebot/src/main.rs
+++ b/tools/bots/welcomebot/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 use std::sync::Arc;
 
 use decentcom_bot::{events::MemberEvent, Bot, Config as BotConfig, Context};
+use tokio::sync::OnceCell;
 use tracing::warn;
 
 use crate::config::Config;
@@ -11,19 +12,25 @@ use crate::config::Config;
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let cfg = Config::load("welcomebot.toml")?;
+    let path = Config::default_path();
+    let cfg = Config::load(&path)?;
+
     let bot_cfg = BotConfig {
         server_url: cfg.server_url.clone(),
         mnemonic: cfg.mnemonic.clone(),
+        seed_hex: cfg.seed_hex.clone(),
         display_name: cfg.display_name.clone(),
     };
 
     let cfg = Arc::new(cfg);
+    // Resolved once on first member-join and reused across reconnects.
+    let channel_id: Arc<OnceCell<String>> = Arc::new(OnceCell::new());
 
     Bot::with_config(bot_cfg)?
         .on_member_join(move |ctx: Context, evt: MemberEvent| {
             let cfg = cfg.clone();
-            async move { handle_join(ctx, evt, &cfg).await }
+            let channel_id = channel_id.clone();
+            async move { handle_join(ctx, evt, &cfg, &channel_id).await }
         })
         .run()
         .await?;
@@ -31,10 +38,22 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn handle_join(ctx: Context, evt: MemberEvent, cfg: &Config) -> anyhow::Result<()> {
+async fn handle_join(
+    ctx: Context,
+    evt: MemberEvent,
+    cfg: &Config,
+    channel_id: &OnceCell<String>,
+) -> anyhow::Result<()> {
     if evt.is_bot {
         return Ok(());
     }
+
+    // Resolve channel name → ID once; reuse on subsequent events.
+    let cid = channel_id
+        .get_or_try_init(|| async {
+            resolve_channel(ctx.sdk(), &cfg.welcome_channel).await
+        })
+        .await?;
 
     let display_name = evt
         .display_name
@@ -47,17 +66,30 @@ async fn handle_join(ctx: Context, evt: MemberEvent, cfg: &Config) -> anyhow::Re
         .replace("{display_name}", &display_name)
         .replace("{pubkey}", &evt.pubkey);
 
-    if let Err(e) = ctx.send(&cfg.welcome_channel_id, &msg).await {
+    if let Err(e) = ctx.send(cid, &msg).await {
         warn!("failed to send welcome message: {e}");
     }
 
     if let Some(rules) = &cfg.rules_message {
-        if let Err(e) = ctx.send(&cfg.welcome_channel_id, rules).await {
+        if let Err(e) = ctx.send(cid, rules).await {
             warn!("failed to send rules message: {e}");
         }
     }
 
     Ok(())
+}
+
+/// Find a channel by name or ID. Returns the channel's server-assigned ID.
+async fn resolve_channel(
+    client: &decentcom_sdk::rest::Client,
+    name_or_id: &str,
+) -> anyhow::Result<String> {
+    let channels = client.channels().list().await?;
+    channels
+        .iter()
+        .find(|c| c.name == name_or_id || c.id == name_or_id)
+        .map(|c| c.id.clone())
+        .ok_or_else(|| anyhow::anyhow!("channel '{}' not found on server", name_or_id))
 }
 
 #[cfg(test)]

--- a/tools/join-user/Cargo.toml
+++ b/tools/join-user/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "join-user"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Create a fresh user identity and join a decentcom server — for local testing."
+
+[[bin]]
+name = "join-user"
+path = "src/main.rs"
+
+[dependencies]
+decentcom-sdk = { workspace = true }
+anyhow = "1"
+tokio = { workspace = true }

--- a/tools/join-user/src/main.rs
+++ b/tools/join-user/src/main.rs
@@ -1,0 +1,46 @@
+use anyhow::{Context, Result};
+use decentcom_sdk::{rest::models::UpdateProfileRequest, Client, Identity};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let server_url = args
+        .next()
+        .unwrap_or_else(|| "http://localhost:8081".to_string());
+    let display_name = args.next();
+
+    let (identity, mnemonic) = Identity::generate().context("failed to generate identity")?;
+
+    println!("New user pubkey:  {}", identity.pubkey());
+    println!("Mnemonic (save to reuse this identity):");
+    println!("  {mnemonic}");
+    println!();
+    println!("Joining {server_url}...");
+
+    let client = Client::new(&server_url).context("failed to build client")?;
+    client
+        .authenticate(&identity)
+        .await
+        .context("authentication failed")?;
+
+    client
+        .members()
+        .join()
+        .await
+        .context("join failed")?;
+
+    if let Some(name) = &display_name {
+        client
+            .profiles()
+            .update(&UpdateProfileRequest {
+                display_name: Some(name.clone()),
+            })
+            .await
+            .context("setting display name failed")?;
+        println!("Joined as \"{name}\" (pubkey: {})", identity.pubkey());
+    } else {
+        println!("Joined (pubkey: {})", identity.pubkey());
+    }
+
+    Ok(())
+}

--- a/tools/test-setup/src/seed/mod.rs
+++ b/tools/test-setup/src/seed/mod.rs
@@ -63,6 +63,7 @@ pub fn print_summary(users: &[User]) {
         println!("  {:<12}  pubkey: {}…", bot.name, &bot.pubkey[..20]);
     }
     println!("  bot-alpha — approved on Open Server (localhost:8081) by sdk-seed");
+    println!("              runs as welcomebot (Procfile) using test-configs/welcomebot.toml");
     println!("  bot-beta  — not registered with any server");
     println!();
     println!("Server Layout (seeded by tools/sdk-seed via the REST API):");


### PR DESCRIPTION
Closes #77

## Summary
Three independent reference bot binaries built on the `decentcom-bot` SDK, each with TOML + env-var config and a README.

## Changes

### welcomebot (`tools/bots/welcomebot/`)
- `on_member_join` handler sends a configurable welcome message (with `{display_name}`/`{pubkey}` template interpolation) to a configured channel, then optionally posts a rules message.
- Skips bots joining.

### modbot (`tools/bots/modbot/`)
- In-memory sliding-window detector for two rule types:
  - **Duplicate messages** — same content N times in T seconds
  - **Link flood** — N `http://`/`https://` URLs in T seconds
- Per-rule action policy: `warn` (post to channel), `kick`, or `ban`.
- State cleared after kick/ban so re-joining starts fresh.

### auditbot (`tools/bots/auditbot/`)
- Configurable sink: **file** (NDJSON, append-safe with async mutex) or **webhook** (HTTP POST JSON).
- Configurable event filter: kick, ban, message delete (on by default); join, leave (off by default).
- Handlers registered only for enabled events.
- Each record: event type, UTC timestamp, relevant IDs/reason.

### Workspace
- Added `decentcom-bot` workspace dep, three new workspace members.

## Testing
- 6 unit tests pass across all three bots (template interpolation, duplicate/link detection, file sink).
- `cargo clippy -- -D warnings`: clean on all three crates.
- Integration tests (live server) are noted in the issue as remaining work.

## Notes
- `timeout` moderation action is omitted (no server endpoint exists yet).
- modbot state is in-memory; a restart resets counters (noted in README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)